### PR TITLE
Improve the chip tab

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@
 /Old_DLC
 /node_modules
 /foundry
-/templates/sidebar
+/templates

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,50 @@
 {
   "DLC": {
+    "app": {
+      "AllocateChips": "Allocate Chips",
+      "ChipAllocator": "Chip Allocator",
+      "ChooseTraits": "You must set each trait with a unique card.",
+      "SetTraits": "Set Traits",
+      "UseMandatory": "You must use all jokers and all twos."
+    },
+
+    "archtypes": {
+      "buffaloGirl": "Buffalo girl",
+      "cayoteBrave": "Cayote brave",
+      "cowpoke": "Cowpoke",
+      "custom": "Retrieve the manually edited values",
+      "gambler": "Gambler",
+      "guacho": "Guacho",
+      "gunslinger": "Gunslinger",
+      "huckster": "Huckster",
+      "kid": "Kid",
+      "madScientist": "Mad Scientist",
+      "manInBlack": "Man-in-Black",
+      "muckraker": "Muckraker",
+      "nun": "Nun",
+      "ponyExpressRider": "Pony Express Rider",
+      "preacher": "Preacher",
+      "prospector": "Prospector",
+      "saloonGal": "Saloon Gal",
+      "sheriff": "Sheriff",
+      "shyster": "Shyster",
+      "siouxShaman": "Sioux Shaman",
+      "soldier": "Soldier",
+      "spy": "Spy",
+      "texasRanger": "Texas Ranger"
+    },
+
+    "arcaneFlavour": {
+      "none": "Not Arcane",
+      "blessed": "Blessed",
+      "huckster": "Huckster",
+      "madScientist": "Mad scientist",
+      "shaman": "Shaman",
+      "harrowed": "Harrowed",
+      "isArcane": "Is this an arcane power",
+      "grantsArcane": "Does this grant an arcane background"
+    },
+
     "combat": {
       "BeginRound": "Begin Round",
       "EndRound": "End Combat Round",
@@ -10,6 +55,45 @@
       "ToggleBlackJoker": "Toggle use black joker",
       "ToggleSleeved": "Toggle use sleeved card",
       "Vamoose": "Vamoose!!"
+    },
+
+    "item": {
+      "Setting": "Active in Game system",
+      "UpdateEdgeMessage": "Update the Edge"
+    },
+
+    "modification": {
+      "Setting": "Active in Game system",
+      "one": "Turn on Level one",
+      "two": "Turn on Level two",
+      "three": "Turn on Level three",
+      "four": "Turn on Level four",
+      "five": "Turn on Level five",
+      "capstone": "Turn on Capstone",
+      "cost": "Bounty cost",
+      "startCost": "Creation points cost",
+      "grantsArcane": "This Edge gives the character an arcane background",
+      "isArcane": "This edge has an arcane background prerequisite"
+    },
+
+    "modificationTab": {
+      "configure": "Configure the Edge",
+      "blurb": "Description",
+      "one": "1",
+      "two": "2",
+      "three": "3",
+      "four": "4",
+      "five": "5",
+      "capstone": "Capstone"
+    },
+
+    "modificationTabConfigure": {
+      "one": "Set the values of level one",
+      "two": "Set the values of level two",
+      "three": "Set the values of level three",
+      "four": "Set the values of level four",
+      "five": "Set the values of level five",
+      "capstone": "Set the values of the capstone"
     },
 
     "settings": {
@@ -56,29 +140,43 @@
       }
     },
 
-    "sheet": {
+    "sheet-type": {
+      "character": "Player Character",
+      "edge": "Edge",
+      "npc": "Non-Player Character"
+    },
+
+    "sidebar": {
+      "ChipAllocator": "Chip Allocator",
+      "ChipPot": "Chips in Pot",
+      "DrawMarshalChip": "Draw a chip for the Marshal",
+      "EditItem": "Edit",
+      "MarshalsChips": "Marshal's Chips",
+      "SetTraits": "Set character's traits",
+      "UseChips": "Toggle participation in the chip pot",
+      "UseMarshalBlue": "Use chip",
+      "UseMarshalRed": "Use chip",
+      "UseMarshalWhite": "Use chip"
+    },
+
+    "tab": {
+      "apt-create": "Initial Aptitudes",
+      "apt-improve": "Improve Aptitudes",
       "aptitudes": "Aptitudes",
       "bio": "Biography",
       "biodata": "Bio-Data",
       "chips": "Chips",
       "combat": "Combat",
+      "edge-create": "Creation Edges",
+      "edge-improve": "Improvement Edges",
       "edges": "Edges",
       "gear": "Inventory",
       "main": "Main",
       "notes": "Notes",
       "spells": "Spells",
-      "chip": { "name": "Chip Management" }
-    },
-
-    "sheet-type": {
-      "character": "Player Character",
-      "npc": "Non-Player Character"
-    },
-
-    "sidebar": {
-      "AllocateChips": "Allocate Chips",
-      "ChipManager": "Chip Manager",
-      "UseChips": "Toggle participation in the chip pot"
+      "trait-create": "Initial Traits",
+      "trait-improve": "Improve Traits",
+      "traits": "Traits"
     },
 
     "traitAbbreviation": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -46,6 +46,8 @@
     },
 
     "character": {
+      "drawOne": "Draw one chip",
+      "drawThree": "Draw three chips",
       "useWhite": "Use white chip",
       "convertWhite": "Convert white chip to bounty",
       "useRed": "Use red chip",

--- a/lang/en.json
+++ b/lang/en.json
@@ -45,6 +45,23 @@
       "grantsArcane": "Does this grant an arcane background"
     },
 
+    "character": {
+      "useWhite": "Use white chip",
+      "convertWhite": "Convert white chip to bounty",
+      "useRed": "Use red chip",
+      "convertRed": "Convert red chip to bounty",
+      "useBlue": "Use blue chip",
+      "convertBlue": "Convert blue chip to bounty",
+      "useGreen": "Use green chip",
+      "convertGreen": "Convert green chip to bounty",
+      "consumeGreen": "Use and consume green chip",
+      "useTemporaryGreen": "Use temporary green chip",
+      "convertTemporaryGreen": "Convert temporary green chip to bounty",
+      "consumeChip": "Consume",
+      "convertChip": "Convert",
+      "useChip": "Use"
+    },
+
     "combat": {
       "BeginRound": "Begin Round",
       "EndRound": "End Combat Round",

--- a/module/apps/chip-allocator.mjs
+++ b/module/apps/chip-allocator.mjs
@@ -1,0 +1,105 @@
+/* eslint-disable no-console */
+/* eslint-disable no-underscore-dangle */
+/**
+ * The sidebar directory which organizes and displays world-level Combat documents.
+ */
+export class ChipAllocator extends FormApplication {
+  /** @inheritdoc */
+
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      template: 'systems/deadlands-classic/templates/chip/allocator.html',
+      scrollY: ['.directory-list'],
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getData(options = {}) {
+    let context = await super.getData(options);
+
+    // Get the actors who can hold chips
+    const chipBearers = game.actors.filter((a) => a.system.hasChips === true);
+
+    const posse = [];
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const actor of chipBearers) {
+      const { name, id, img } = actor;
+      posse.push({ name, id, img });
+    }
+
+    context = foundry.utils.mergeObject(context, {
+      posse,
+    });
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle standard form submission steps
+   * @param {Event} event               The submit event which triggered this handler
+   * @param {object | null} [updateData]  Additional specific data keys/values which override or extend the contents of
+   *                                    the parsed form. This can be used to update other flags or data fields at the
+   *                                    same time as processing a form submission to avoid multiple database operations.
+   * @param {boolean} [preventClose]    Override the standard behavior of whether to close the form on submit
+   * @param {boolean} [preventRender]   Prevent the application from re-rendering as a result of form submission
+   * @returns {Promise}                 A promise which resolves to the validated update data
+   * @protected
+   */
+  async _onSubmit(
+    event,
+    { updateData = null, preventClose = false, preventRender = false } = {}
+  ) {
+    event.preventDefault();
+
+    // Prevent double submission
+    const states = this.constructor.RENDER_STATES;
+    if (this._state === states.NONE || !this.isEditable || this._submitting)
+      return false;
+    this._submitting = true;
+
+    // Handle the form state prior to submission
+    let closeForm = this.options.closeOnSubmit && !preventClose;
+    const priorState = this._state;
+    if (preventRender) this._state = states.RENDERING;
+    if (closeForm) this._state = states.CLOSING;
+
+    // Process the form data
+    const formData = this._getSubmitData(updateData);
+
+    // extract the form data
+    const { white, red, blue, green, temporaryGreen, ...actors } = formData;
+    const allocate = { white, red, blue, green, temporaryGreen };
+
+    const receiverIds = Object.keys(actors).filter(
+      (k) => actors[k] === 'checked'
+    );
+
+    // Trigger the object update
+    try {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const actorId of receiverIds) {
+        game['deadlands-classic'].socket.executeAsGM(
+          'socketAddChipsActor',
+          actorId,
+          allocate
+        );
+      }
+    } catch (err) {
+      console.error(err);
+      closeForm = false;
+      this._state = priorState;
+    }
+
+    // Restore flags and optionally close the form
+    this._submitting = false;
+    if (preventRender) this._state = priorState;
+    if (closeForm) await this.close({ submit: false, force: true });
+    return formData;
+  }
+}

--- a/module/deadlands-classic.mjs
+++ b/module/deadlands-classic.mjs
@@ -70,7 +70,6 @@ Hooks.once('init', async () => {
   registerSocketFunctions(socket);
 
   /* -------------------------------------------- */
-
   if (!('chips' in globalThis.game)) {
     game.chips = {};
     game.chips.apps = {};
@@ -96,12 +95,12 @@ Hooks.once('init', async () => {
 Hooks.once('setup', async () => {
   // eslint-disable-next-line no-console
   console.log('Deadlands Classic | Setting Up');
+  Chips.buildCurrentChipPool();
 });
 
 Hooks.once('ready', async () => {
   // eslint-disable-next-line no-console
   console.log('Deadlands Classic | Readying');
-  Chips.buildCurrentChipPool();
 });
 
 Hooks.on('renderSidebar', async (app, html) => {

--- a/module/documents/dlc-actor.mjs
+++ b/module/documents/dlc-actor.mjs
@@ -1,4 +1,5 @@
 import { Chips } from '../helpers/chips.mjs';
+import { NumberString } from '../helpers/number-string.mjs';
 
 export class DeadlandsActor extends Actor {
   // eslint-disable-next-line no-useless-constructor
@@ -6,8 +7,10 @@ export class DeadlandsActor extends Actor {
     super(data, context);
   }
 
-  async removeChip(type, addBounty) {
-    let { white, red, blue, green, temporaryGreen, careerBounty } = this.system;
+  async removeSingleChip(type, addBounty) {
+    const actorData = this.system.toObject();
+
+    let { white, red, blue, green, temporaryGreen, careerBounty } = actorData;
 
     if (type === Chips.type.White && white > 0) {
       white -= 1;
@@ -35,14 +38,158 @@ export class DeadlandsActor extends Actor {
   }
 
   async useChip(type) {
-    this.removeChip(type, false);
+    this.removeSingleChip(type, false);
   }
 
   async convertChip(type) {
-    this.removeChip(type, true);
+    this.removeSingleChip(type, true);
   }
 
-  async grantChip(type) {
+  static #makeSub(count, string) {
+    const suffix = count > 1 ? 's' : '';
+    const num = NumberString.makeString(count);
+    return count < 1 ? '' : num + string + suffix;
+  }
+
+  static #makeReport(action, chips) {
+    const strings = [];
+
+    let str = DeadlandsActor.#makeSub(
+      chips.temporaryGreen,
+      ' temporary green chip'
+    );
+    if (str !== '') strings.push(str);
+
+    str = DeadlandsActor.#makeSub(chips.green, ' green chip');
+    if (str !== '') strings.push(str);
+
+    str = DeadlandsActor.#makeSub(chips.blue, ' blue chip');
+    if (str !== '') strings.push(str);
+
+    str = DeadlandsActor.#makeSub(chips.red, ' red chip');
+    if (str !== '') strings.push(str);
+
+    str = DeadlandsActor.#makeSub(chips.white, ' white chip');
+    if (str !== '') strings.push(str);
+
+    let report = `${action} `;
+    let added = false;
+
+    while (strings.length > 1) {
+      if (added) report += ', ';
+      report += strings.shift();
+      added = true;
+    }
+
+    report += added ? ' and ' : '';
+    report += strings.shift();
+
+    return report;
+  }
+
+  async addMultipleChips({
+    white = 0,
+    red = 0,
+    blue = 0,
+    green = 0,
+    temporaryGreen = 0,
+  } = {}) {
+    // Chips being added
+    const adding = {
+      white,
+      red,
+      blue,
+      green,
+      temporaryGreen,
+    };
+
+    // How many chips are being added
+    const totalAdding = white + red + blue + green + temporaryGreen;
+
+    // If nothing to actually add
+    if (totalAdding < 1) return '';
+
+    const localAct = this.toObject();
+
+    localAct.system.white += white;
+    localAct.system.red += red;
+    localAct.system.blue += blue;
+    localAct.system.green += green;
+    localAct.system.temporaryGreen += temporaryGreen;
+
+    // How many total chips does this actor now have
+    let total =
+      localAct.system.white +
+      localAct.system.red +
+      localAct.system.blue +
+      localAct.system.green +
+      localAct.system.temporaryGreen;
+
+    const converting = {
+      white: 0,
+      red: 0,
+      blue: 0,
+      green: 0,
+      temporaryGreen: 0,
+    };
+
+    // Reduce the combined chip collection to total 10 or less. Populate converting with chips
+    // to convert to bounty.
+
+    while (total > 10) {
+      if (localAct.system.white > 0) {
+        localAct.system.careerBounty += 1;
+        localAct.system.white -= 1;
+        converting.white += 1;
+        total -= 1;
+      } else if (localAct.system.red > 0) {
+        localAct.system.careerBounty += 2;
+        localAct.system.red -= 1;
+        converting.red += 1;
+        total -= 1;
+      } else if (localAct.system.blue > 0) {
+        localAct.system.careerBounty += 3;
+        localAct.system.blue -= 1;
+        converting.blue += 1;
+        total -= 1;
+      } else if (localAct.system.green > 0) {
+        localAct.system.careerBounty += 5;
+        localAct.system.green -= 1;
+        converting.green += 1;
+        total -= 1;
+      } else if (localAct.system.temporaryGreen > 0) {
+        localAct.system.careerBounty += 5;
+        localAct.system.temporaryGreen -= 1;
+        converting.temporaryGreen += 1;
+        total -= 1;
+      }
+    }
+
+    // **********************************************************************
+    // Got the adjustments
+
+    // How many total chips (if any) are being converted
+    const totalConverting =
+      converting.white +
+      converting.red +
+      converting.blue +
+      converting.green +
+      converting.temporaryGreen;
+
+    let chatStr = DeadlandsActor.#makeReport('Added', adding);
+
+    if (totalConverting > 0) {
+      chatStr += `${DeadlandsActor.#makeReport(
+        '. Converted',
+        converting
+      )} to bounty.`;
+    }
+
+    this.update(localAct, {});
+    return chatStr;
+  }
+
+  async addChip(type) {
     // Convert a Chip if necessary to have 10 or fewer
 
     let { white, red, blue, green, temporaryGreen, careerBounty } = this.system;

--- a/module/helpers/chips.mjs
+++ b/module/helpers/chips.mjs
@@ -15,7 +15,7 @@ export class Chips {
   static randomDraw(includeGreen) {
     const { white, red, blue, green } = game.chips.available;
 
-    const available = white + red + blue + includeGreen ? green : 0;
+    const available = white + red + blue + (includeGreen ? green : 0);
     const picked = Deck.getRandomInteger(1, available);
 
     let pick = Chips.type.NoChip;
@@ -45,7 +45,7 @@ export class Chips {
     const maxBlue = game.settings.get('deadlands-classic', 'blue-chips');
     const maxGreen = game.settings.get('deadlands-classic', 'green-chips');
 
-    const marshal = game.settings.get('deadlands-classic', 'marshall-chips');
+    const marshal = game.settings.get('deadlands-classic', 'marshal-chips');
 
     let { white, red, blue } = marshal.chips;
     let green = 0;

--- a/module/helpers/chips.mjs
+++ b/module/helpers/chips.mjs
@@ -10,6 +10,19 @@ export class Chips {
     TemporaryGreen: 5,
   };
 
+  static colour = {
+    NoChip: 'None',
+    White: 'white',
+    Red: 'red',
+    Blue: 'blue',
+    Green: 'green',
+    TemporaryGreen: 'temporary green',
+  };
+
+  static getColour(type) {
+    return this.colour(type);
+  }
+
   // Choose a randomn chip from those available in the pot. The Marshall can't get green
   // chips, so we need to distinguish if those are avaialble.
   static randomDraw(includeGreen) {
@@ -35,6 +48,29 @@ export class Chips {
     }
 
     return pick;
+  }
+
+  static addToChipCollection(chip, collection) {
+    const newCollection = foundry.utils.deepClone(collection);
+    switch (chip) {
+      case Chips.type.White:
+        newCollection.white += 1;
+        break;
+      case Chips.type.Red:
+        newCollection.red += 1;
+        break;
+      case Chips.type.Blue:
+        newCollection.blue += 1;
+        break;
+      case Chips.type.Green:
+        newCollection.green += 1;
+        break;
+      case Chips.type.TemporaryGreen:
+        newCollection.temporaryGreen += 1;
+        break;
+      default:
+    }
+    return newCollection;
   }
 
   static buildCurrentChipPool() {

--- a/module/helpers/dlc-utilities.mjs
+++ b/module/helpers/dlc-utilities.mjs
@@ -1,0 +1,15 @@
+export function chatMessage(
+  speaker = ChatMessage.getSpeaker(),
+  title = 'Message',
+  message = 'Forgot something...'
+) {
+  const chatData = {
+    title,
+    content: `<div><h2>${title}</h2>${message}</div>`,
+    user: game.user.id,
+    speaker,
+    type: globalThis.CONST.CHAT_MESSAGE_TYPES.OTHER,
+  };
+
+  ChatMessage.create(chatData);
+}

--- a/module/helpers/number-string.mjs
+++ b/module/helpers/number-string.mjs
@@ -1,0 +1,75 @@
+export class NumberString {
+  static digit = [
+    '',
+    'one',
+    'two',
+    'three',
+    'four',
+    'five',
+    'six',
+    'seven',
+    'eight',
+    'nine',
+  ];
+
+  static teens = [
+    'ten',
+    'eleven',
+    'twelve',
+    'thirteen',
+    'fourteen',
+    'fifteen',
+    'sixteen',
+    'seventeen',
+    'eighteen',
+    'nineteen',
+  ];
+
+  static tens = [
+    'twenty',
+    'thirty',
+    'forty',
+    'fifty',
+    'sixty',
+    'seventy',
+    'eighty',
+    'ninety',
+  ];
+
+  static makeString(num) {
+    let n = Number(num);
+
+    // Only handles numbers between zero and nine hundred and ninety nine
+    if (Number.isNaN(n) || n < 0 || n > 999) return 'Out of range';
+
+    n = Math.floor(n);
+
+    // don't put this at the end
+    if (n === 0) return 'Zero';
+
+    let retVal = '';
+
+    if (n > 99) {
+      retVal += this.digit[Math.trunc(n / 100)];
+      retVal += ' Hundred';
+      n %= 100;
+      if (n > 0) {
+        retVal += ' and ';
+      }
+    }
+    if (n > 19) {
+      retVal += this.tens[Math.trunc(n / 10 - 2)];
+      n %= 10;
+      if (n > 0) {
+        retVal += ' ';
+      }
+    }
+    if (n > 9) {
+      retVal += this.teens[n - 10];
+    } else {
+      retVal += this.digit[n];
+    }
+
+    return retVal;
+  }
+}

--- a/module/init/add-chip-tab.mjs
+++ b/module/init/add-chip-tab.mjs
@@ -8,10 +8,12 @@ export function addChipTab(app, html) {
   if (!game.user.isGM) return;
 
   const computedWidth = Math.floor(
-    parseInt(getComputedStyle(html[0]).getPropertyValue('--sidebar-width'), 10)
-     /
-    (document.querySelector('#sidebar-tabs').childElementCount + 1)
-  )
+    parseInt(
+      getComputedStyle(html[0]).getPropertyValue('--sidebar-width'),
+      10
+    ) /
+      (document.querySelector('#sidebar-tabs').childElementCount + 1)
+  );
   // Calculate new tab width
   html[0]
     .querySelector('#sidebar-tabs')

--- a/module/init/settings.mjs
+++ b/module/init/settings.mjs
@@ -87,7 +87,7 @@ export function createGameSettings() {
     default: 0,
   });
 
-  game.settings.register('deadlands-classic', 'marshall-chips', {
+  game.settings.register('deadlands-classic', 'marshal-chips', {
     name: 'DLC.settings.chips-marshal.name',
     hint: 'DLC.settings.chips-marshal.hint',
     scope: 'world',

--- a/module/init/socket-functions.mjs
+++ b/module/init/socket-functions.mjs
@@ -127,7 +127,7 @@ async function socketDrawChipActor(actorId, num = 1) {
   // Adding the randomly drawn chip.
   const message = await actor.addMultipleChips(chipobject);
 
-  _chatMessage(ChatMessage.getSpeaker(), 'Chips drawn', message);
+  _chatMessage(ChatMessage.getSpeaker(), actor.name, message);
 }
 
 async function socketDrawChipMarshal() {

--- a/module/sheets/dlc-actor-sheet.mjs
+++ b/module/sheets/dlc-actor-sheet.mjs
@@ -41,13 +41,13 @@ export class DLCActorSheet extends ActorSheet {
     const actorSystem = actor.system;
     const keys = Object.keys(actorSystem);
 
-    const validChips = new Map([
-      ['white', true],
-      ['red', true],
-      ['blue', true],
-      ['green', true],
-      ['temporaryGreen', true],
-    ]);
+    const validChips = {
+      white: 0,
+      red: 0,
+      blue: 0,
+      green: 0,
+      temporaryGreen: 0,
+    };
 
     // eslint-disable-next-line no-restricted-syntax, guard-for-in
     for (const key of keys.values()) {
@@ -60,9 +60,6 @@ export class DLCActorSheet extends ActorSheet {
               break;
             case 'aptitude':
               aptitudes[key] = slot;
-              break;
-            case 'chip':
-              chips[key] = slot;
               break;
             default:
             // There is no default case, the document validation has restriced
@@ -81,8 +78,7 @@ export class DLCActorSheet extends ActorSheet {
       const value = aptitudes[key];
       const trait = actorSystem[value.trait];
       value.die = trait?.dieSize ?? 4;
-      value.totalRanks =
-        value.defaultRanks.value + value.ranks.value + value.startRanks.value;
+      value.totalRanks = value.defaultRanks + value.ranks + value.startRanks;
       value.show = value.totalRanks !== 0;
 
       const confEntry = dlcConfig.aptitudes[key];

--- a/module/sheets/dlc-actor-sheet.mjs
+++ b/module/sheets/dlc-actor-sheet.mjs
@@ -1,4 +1,5 @@
 import { dlcConfig } from '../config.mjs';
+import { Chips } from '../helpers/chips.mjs';
 
 export class DLCActorSheet extends ActorSheet {
   static get defaultOptions() {
@@ -67,6 +68,7 @@ export class DLCActorSheet extends ActorSheet {
           }
         } else if (key in validChips) {
           chips[key] = slot;
+          chips[`has${key}`] = slot > 0;
         } else {
           unclassified[key] = slot;
         }
@@ -111,5 +113,118 @@ export class DLCActorSheet extends ActorSheet {
     });
 
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    // chip control
+    html.find('.chip-control').click((ev) => this.#onChipControl(ev));
+  }
+
+  /**
+   * Handle a chip allocation event
+   * @private
+   * @param {Event} event The originating mousedown event
+   */
+  async #onChipControl(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const btn = event.currentTarget;
+
+    // eslint-disable-next-line default-case
+    switch (btn.dataset.control) {
+      case 'useWhite':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketUseChipActor',
+          this.document.id,
+          Chips.type.White
+        );
+        break;
+
+      case 'useRed':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketUseChipActor',
+          this.document.id,
+          Chips.type.Red
+        );
+        break;
+
+      case 'useBlue':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketUseChipActor',
+          this.document.id,
+          Chips.type.Blue
+        );
+        break;
+
+      case 'useGreen':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketUseChipActor',
+          this.document.id,
+          Chips.type.Green
+        );
+        break;
+
+      case 'useTemporaryGreen':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketUseChipActor',
+          this.document.id,
+          Chips.type.TemporaryGreen
+        );
+        break;
+
+      case 'convertWhite':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketConvertChipActor',
+          this.document.id,
+          Chips.type.White
+        );
+        break;
+
+      case 'convertRed':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketConvertChipActor',
+          this.document.id,
+          Chips.type.Red
+        );
+        break;
+
+      case 'convertBlue':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketConvertChipActor',
+          this.document.id,
+          Chips.type.Blue
+        );
+        break;
+
+      case 'convertGreen':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketConvertChipActor',
+          this.document.id,
+          Chips.type.Green
+        );
+        break;
+
+      case 'convertTemporaryGreen':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketConvertChipActor',
+          this.document.id,
+          Chips.type.TemporaryGreen
+        );
+        break;
+
+      case 'consumeGreen':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketConsumeGreenChipActor',
+          this.document.id
+        );
+        break;
+    }
+    this.render();
   }
 }

--- a/module/sheets/dlc-actor-sheet.mjs
+++ b/module/sheets/dlc-actor-sheet.mjs
@@ -224,6 +224,22 @@ export class DLCActorSheet extends ActorSheet {
           this.document.id
         );
         break;
+
+      case 'drawOne':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketDrawChipActor',
+          this.document.id,
+          1
+        );
+        break;
+
+      case 'drawThree':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketDrawChipActor',
+          this.document.id,
+          3
+        );
+        break;
     }
     this.render();
   }

--- a/module/sidebar/chip-manager.mjs
+++ b/module/sidebar/chip-manager.mjs
@@ -1,3 +1,8 @@
+import { ChipAllocator } from '../apps/chip-allocator.mjs';
+import { Chips } from '../helpers/chips.mjs';
+
+/* eslint-disable no-console */
+/* eslint-disable no-underscore-dangle */
 /**
  * The sidebar directory which organizes and displays world-level Combat documents.
  */
@@ -6,6 +11,15 @@ export class ChipManager extends SidebarTab {
     super(options);
     /* global ui */
     if (ui.sidebar) ui.sidebar.tabs.chips = this;
+
+    /* This will hold the application used when allocating chips */
+    Object.defineProperty(this, '_chipAllocator', {
+      value: null,
+      writable: true,
+      enumerable: false,
+    });
+
+    globalThis.ChipManager = this;
   }
 
   /* -------------------------------------------- */
@@ -16,7 +30,6 @@ export class ChipManager extends SidebarTab {
     return foundry.utils.mergeObject(super.defaultOptions, {
       id: 'chips',
       template: 'systems/deadlands-classic/templates/sidebar/chip-manager.html',
-      title: game.i18n.localize('DLC.sheet.chip'),
       scrollY: ['.directory-list'],
     });
   }
@@ -27,26 +40,109 @@ export class ChipManager extends SidebarTab {
 
   /** @inheritdoc */
   async getData(options = {}) {
+    // Update the game's notion of which chips are available
+    Chips.buildCurrentChipPool();
+
+    const { white, red, blue, green } = game.chips.available;
+
+    const marshal = game.settings.get('deadlands-classic', 'marshal-chips');
+
+    const chips = {
+      white,
+      red,
+      blue,
+      green,
+
+      hasWhite: marshal.chips.white > 0,
+      hasRed: marshal.chips.red > 0,
+      hasBlue: marshal.chips.blue > 0,
+
+      marshalWhite: marshal.chips.white,
+      marshalRed: marshal.chips.red,
+      marshalBlue: marshal.chips.blue,
+    };
+
     let context = await super.getData(options);
+    context = foundry.utils.mergeObject(context, { chips });
 
-    // Get the actors who can hold chips
-    const chipBearers = game.actors.filter(
-      (a) => a.system.ActiveForChips === true
-    );
+    return context;
+  }
 
-    const posse = [];
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    // chip control
+    html.find('.chip-control').click((ev) => this.#onChipControl(ev));
+  }
+
+  /**
+   * Handle a chip allocation event
+   * @private
+   * @param {Event} event The originating mousedown event
+   */
+  async #onChipControl(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const btn = event.currentTarget;
+
+    if (btn.dataset.control === 'chipAllocator') {
+      if (!this._chipAllocator) {
+        this._chipAllocator = new ChipAllocator(this, {});
+      }
+      this._chipAllocator.render(true);
+    } else if (btn.dataset.control === 'drawChip') {
+      await game['deadlands-classic'].socket.executeAsGM(
+        'socketDrawChipMarshal'
+      );
+      this.render();
+    } else {
+      const marshal = game.settings.get('deadlands-classic', 'marshal-chips');
+      const newMarshal = marshal.toObject();
+
+      let updated = false;
+
+      if (btn.dataset.control === 'useMarshalBlue') {
+        if (newMarshal.chips.blue > 0) {
+          newMarshal.chips.blue -= 1;
+          updated = true;
+        }
+      } else if (btn.dataset.control === 'useMarshalRed') {
+        if (newMarshal.chips.red > 0) {
+          newMarshal.chips.red -= 1;
+          updated = true;
+        }
+      } else if (btn.dataset.control === 'useMarshalWhite') {
+        if (newMarshal.chips.white > 0) {
+          newMarshal.chips.white -= 1;
+          updated = true;
+        }
+      }
+
+      if (updated) {
+        await game.settings.set(
+          'deadlands-classic',
+          'marshal-chips',
+          newMarshal
+        );
+        this.render();
+      }
+    }
+  }
+
+  /** @override */
+  async _render(force = false, options = {}) {
+    await super._render(force, options);
+
+    const isPc = game.actors.filter((actor) => actor.system.hasChips);
 
     // eslint-disable-next-line no-restricted-syntax
-    for (const actor of chipBearers) {
-      const { name } = actor;
-      const { id } = actor;
-      const { img } = actor;
-      posse.push({ name, id, img });
+    for (const actor of Object.values(isPc)) {
+      // Register the active Application with the referenced Documents
+      actor.apps[this.appId] = this;
     }
-
-    context = foundry.utils.mergeObject(context, {
-      posse,
-    });
-    return context;
   }
 }

--- a/module/sidebar/dlc-actors-directory.mjs
+++ b/module/sidebar/dlc-actors-directory.mjs
@@ -14,6 +14,11 @@ export class DeadlandsActorDirectory extends ActorDirectory {
         condition: (li) => true,
         callback: (li) => {
           const actor = game.actors.get(li.data('documentId'));
+          if (actor.system.ActiveForChips) {
+            delete actor.apps?.[globalThis.ChipManager.appId];
+          } else {
+            actor.apps[globalThis.ChipManager.appId] = globalThis.ChipManager;
+          }
           actor.system.ActiveForChips = !actor.system.ActiveForChips;
           actor.update();
         },

--- a/styles/dlc.css
+++ b/styles/dlc.css
@@ -121,10 +121,9 @@ li.combatant .roll:hover {
 }
 
 .chip-entry {
-  display: grid;
+  display: flex;
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
   grid-template-columns: 180px 40px;
-  gap: 10px;
-  padding: 10px;
 }
 
 /* ----------------------------------------- */
@@ -155,13 +154,18 @@ li.combatant .roll:hover {
   text-align: right;
 }
 
+.chip-button {
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+}
+
 .chip-button-narrow {
   width: 100px;
   flex: 0 0 calc(var(--sidebar-header-height) * 2px);
 }
 
-.chip-button {
-  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+.chip-button-narrow-character {
+  width: 100px;
+  flex: 0 0 calc(var(--sidebar-header-height) * 1.5px);
 }
 
 .chip-quantity {
@@ -171,12 +175,30 @@ li.combatant .roll:hover {
   justify-content: flex-start;
 }
 
+.chip-quantity-character {
+  flex: 0 0 calc(var(--sidebar-header-height) * 1px);
+  padding: 0.75em;
+  color: var(--color-text-dark-1);
+  justify-content: flex-start;
+  vertical-align: middle;
+}
+
 .chip-label {
   display: flex;
-  flex: 6;
-  padding: 0.5em;
+  padding: 0.75em;
   color: var(--color-text-light-1);
+  justify-content: first baseline;
+  width: 300px;
+}
+
+.chip-label-character {
+  display: flex;
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+  padding: 0.75em;
+  color: var(--color-text-dark-1);
   justify-content: flex-start;
+  vertical-align: middle;
+  width: 130px;
 }
 
 .chip-row {

--- a/styles/dlc.css
+++ b/styles/dlc.css
@@ -131,6 +131,64 @@ li.combatant .roll:hover {
 /*  Chip Manager                             */
 /* ----------------------------------------- */
 
+.chip-allocator-header {
+  --control-width: 24px;
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+  line-height: var(--sidebar-header-height);
+  font-size: var(--font-size-20);
+  text-align: center;
+  border-bottom: 2px groove var(--color-border-dark-4);
+}
+.chip-allocator h3 {
+  flex: 2;
+  margin: 0;
+  font-size: var(--font-size-16);
+  text-align: center;
+}
+
+.chip-box {
+  display: flex;
+  flex: 1;
+  padding: 0.5em;
+  color: var(--color-text-light-0);
+  align-content: flex-start;
+  text-align: right;
+}
+
+.chip-button-narrow {
+  width: 100px;
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+}
+
+.chip-button {
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+}
+
+.chip-quantity {
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+  padding: 0.75em;
+  color: var(--color-text-light-1);
+  justify-content: flex-start;
+}
+
+.chip-label {
+  display: flex;
+  flex: 6;
+  padding: 0.5em;
+  color: var(--color-text-light-1);
+  justify-content: flex-start;
+}
+
+.chip-row {
+  display: flex;
+  flex-direction: row;
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+  align-items: center;
+  overflow: hidden;
+  margin: 0 5px;
+  color: var(--color-text-light-0);
+}
+
 .directory li.chip-actor {
   line-height: var(--sidebar-item-height);
   border-top: 1px solid transparent;
@@ -200,30 +258,6 @@ li.combatant .roll:hover {
   align-self: center;
 }
 
-.chips-sidebar .chip-row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  overflow: hidden;
-  margin: 0 5px;
-  color: var(--color-text-light-0);
-}
-.chips-sidebar .chip-label {
-  display: flex;
-  flex: 6;
-  padding: 0.5em;
-  color: var(--color-text-light-1);
-  justify-content: flex-start;
-}
-.chips-sidebar .chip-box {
-  display: flex;
-  flex: 1;
-  padding: 0.5em;
-  color: var(--color-text-light-0);
-  align-content: flex-start;
-  text-align: right;
-}
-
 .chips-sidebar #combat-controls {
   margin: 0;
   border-top: 2px groove var(--color-border-dark-4);
@@ -239,118 +273,6 @@ li.combatant .roll:hover {
   flex: 3;
 }
 
-/*.chips-sidebar .chip-manager-header a.combat-button {
-  font-size: var(--font-size-14);
-  flex: 0 0 var(--control-width);
-  color: var(--color-text-light-6);
-}
-.chips-sidebar .chip-manager-header a.combat-button.combat-cycle {
-  font-size: var(--font-size-24);
-}
-.chips-sidebar .chip-manager-header a.combat-button[disabled] {
-  visibility: hidden;
-}
-.chips-sidebar .chip-manager-header nav.encounters h4 {
-  flex: 1;
-  margin: 0;
-  font-size: var(--font-size-14);
-  color: var(--color-text-light-5);
-  text-align: center;
-}
-.chips-sidebar .chip-manager-header div.encounter-controls h3 {
-  flex: 2;
-  margin: 0;
-  font-size: var(--font-size-16);
-  text-align: center;
-}
-.chips-sidebar .chip-manager-header div.encounter-controls .encounter-title {
-  margin-left: var(--control-width);
-}
-.chips-sidebar #chip-manager {
-  height: calc(100% - (var(--sidebar-header-height) * 3px - 2px));
-  padding: 1px 0;
-}*/
-
-/*
-.chips-sidebar li.chip-actor .token-name .combatant-controls {
-  flex: 0 0 20px;
-  font-size: var(--font-size-14);
-  line-height: 20px;
-}
-.chips-sidebar li.chip-actor .token-name .combatant-control {
-  flex: 0 0 20px;
-  height: 20px;
-  float: left;
-  color: var(--color-text-dark-5);
-}
-.chips-sidebar li.chip-actor .token-name .combatant-control.active {
-  color: var(--color-text-light-1);
-}
-.chips-sidebar li.chip-actor .token-name .token-effects {
-  height: 20px;
-  overflow: hidden;
-}
-.chips-sidebar li.chip-actor .token-name img.token-effect {
-  width: 16px;
-  height: 16px;
-  margin: 1px 0;
-  border: none;
-  border-radius: 0;
-}
-.chips-sidebar li.chip-actor .token-resource {
-  flex: 0 0 32px;
-  color: var(--color-text-light-4);
-  text-align: center;
-  border-right: 1px solid var(--color-border-dark-2);
-}
-.chips-sidebar li.chip-actor .token-initiative {
-  flex: 0 0 48px;
-  text-align: center;
-}
-.chips-sidebar li.chip-actor .token-initiative .initiative {
-  font-size: var(--font-size-14);
-  text-shadow: 1px 1px 4px var(--color-shadow-dark);
-}
-.chips-sidebar li.chip-actor .roll {
-  display: block;
-  width: 40px;
-  height: var(--sidebar-item-height);
-  background: url(../icons/svg/d20.svg) no-repeat 50% 50%;
-  background-size: 32px;
-  margin: 0 0.5em;
-}
-.chips-sidebar li.chip-actor .roll:hover {
-  background-image: url(../icons/svg/d20-highlight.svg);
-}
-.chips-sidebar li.chip-actor.hover,
-.chips-sidebar li.chip-actor:hover {
-  background: rgba(255, 255, 255, 0.08);
-}
-.chips-sidebar li.chip-actor.active {
-  background: rgba(255, 255, 255, 0.1);
-}
-.chips-sidebar li.chip-actor.active .initiative {
-  font-weight: bold;
-}
-.chips-sidebar li.chip-actor.hidden {
-  color: var(--color-text-light-7);
-}
-.chips-sidebar li.chip-actor.hidden img {
-  opacity: 0.3;
-}
-.chips-sidebar li.chip-actor.hidden.flexrow {
-  display: flex;
-}
-.chips-sidebar li.chip-actor.defeated {
-  color: #b32019;
-}
-.chips-sidebar li.chip-actor.defeated img {
-  opacity: 0.3;
-  transform: scale(0.75);
-}*/
-
-.dlc {
-}
 .dlc .sheet-header {
   flex: 0 0 100px;
   overflow: hidden;

--- a/templates/chip/allocator.html
+++ b/templates/chip/allocator.html
@@ -8,23 +8,23 @@
 
   <form>
     <div class="chip-row">
-      <label class="chip-label" for="white">White</label>
+      <label class="chip-label-character" for="white">White</label>
       <input class="chip-box" type="number" name="white" value="0" maxlength="2">
     </div>
     <div class="chip-row">
-      <label class="chip-label" for="red">Red</label>
+      <label class="chip-label-character" for="red">Red</label>
       <input class="chip-box" type="number" name="red" value="0" maxlength="2">
     </div>
     <div class="chip-row">
-      <label class="chip-label" for="blue">Blue</label>
+      <label class="chip-label-character" for="blue">Blue</label>
       <input class="chip-box" type="number" name="blue" value="0" maxlength="2">
     </div>
     <div class="chip-row">
-      <label class="chip-label" for="green">Green</label>
+      <label class="chip-label-character" for="green">Green</label>
       <input class="chip-box" type="number" name="green" value="0" maxlength="2">
     </div>
     <div class="chip-row">
-      <label class="chip-label" for="tGreen">Temp Green</label>
+      <label class="chip-label-character" for="tGreen">Temp Green</label>
       <input class="chip-box" type="number" name="temporaryGreen" value="0" maxlength="2">
     </div>
     <ol class="directory-list">

--- a/templates/chip/allocator.html
+++ b/templates/chip/allocator.html
@@ -1,0 +1,47 @@
+<section class="{{cssClass}} directory flexcol" id="{{cssId}}" data-tab="{{tabName}}">
+
+  <header class="chip-allocator-header">
+      <div class="flexrow">
+        <h3 class="chip-allocator noborder">{{localize 'DLC.app.ChipAllocator'}}</h3>
+      </div>
+  </header>
+
+  <form>
+    <div class="chip-row">
+      <label class="chip-label" for="white">White</label>
+      <input class="chip-box" type="number" name="white" value="0" maxlength="2">
+    </div>
+    <div class="chip-row">
+      <label class="chip-label" for="red">Red</label>
+      <input class="chip-box" type="number" name="red" value="0" maxlength="2">
+    </div>
+    <div class="chip-row">
+      <label class="chip-label" for="blue">Blue</label>
+      <input class="chip-box" type="number" name="blue" value="0" maxlength="2">
+    </div>
+    <div class="chip-row">
+      <label class="chip-label" for="green">Green</label>
+      <input class="chip-box" type="number" name="green" value="0" maxlength="2">
+    </div>
+    <div class="chip-row">
+      <label class="chip-label" for="tGreen">Temp Green</label>
+      <input class="chip-box" type="number" name="temporaryGreen" value="0" maxlength="2">
+    </div>
+    <ol class="directory-list">
+      {{#each posse as |actor|}}
+        <div class="flexcol">
+          <li class="document chip-actor flexrow" data-actor-id="{{actor.id}}" data-index={{@index}}>
+            <img class="thumbnail" src="{{actor.img}}" data-src="{{actor.img}}" alt="{{actor.name}}"/>
+            <div class="token-name"><h4>{{actor.name}}</h4></div>
+            <input class="token-box" type="checkbox" name="{{actor.id}}" value="checked">
+          </li>
+        </div>
+      {{/each}}
+    </ol>
+    
+    <input type="submit" value={{localize 'DLC.app.AllocateChips'}} />
+
+</form>
+
+
+</section>

--- a/templates/dlc-character-sheet.html
+++ b/templates/dlc-character-sheet.html
@@ -22,18 +22,18 @@
   </header>
   {{!-- Sheet Tab Navigation --}}
   <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="main"> {{localize "DLC.sheet.main"}} </a>
-    <a class="item" data-tab="chips"> {{localize "DLC.sheet.chips"}} </a>
-    <a class="item" data-tab="combat"> {{localize "DLC.sheet.combat"}} </a>
+    <a class="item" data-tab="main"> {{localize "DLC.tab.main"}} </a>
+    <a class="item" data-tab="chips"> {{localize "DLC.tab.chips"}} </a>
+    <a class="item" data-tab="combat"> {{localize "DLC.tab.combat"}} </a>
     <a class="item" data-tab="aptitudes">
-      {{localize "DLC.sheet.aptitudes"}}
+      {{localize "DLC.tab.aptitudes"}}
     </a>
-    <a class="item" data-tab="edges"> {{localize "DLC.sheet.edges"}} </a>
-    <a class="item" data-tab="gear"> {{localize "DLC.sheet.gear"}} </a>
-    <a class="item" data-tab="spells"> {{localize "DLC.sheet.spells"}} </a>
-    <a class="item" data-tab="biodata"> {{localize "DLC.sheet.biodata"}} </a>
-    <a class="item" data-tab="bio"> {{localize "DLC.sheet.bio"}} </a>
-    <a class="item" data-tab="notes"> {{localize "DLC.sheet.notes"}} </a>
+    <a class="item" data-tab="edges"> {{localize "DLC.tab.edges"}} </a>
+    <a class="item" data-tab="gear"> {{localize "DLC.tab.gear"}} </a>
+    <a class="item" data-tab="spells"> {{localize "DLC.tab.spells"}} </a>
+    <a class="item" data-tab="biodata"> {{localize "DLC.tab.biodata"}} </a>
+    <a class="item" data-tab="bio"> {{localize "DLC.tab.bio"}} </a>
+    <a class="item" data-tab="notes"> {{localize "DLC.tab.notes"}} </a>
   </nav>
   {{!-- Sheet Body --}}
   <section class="sheet-body">

--- a/templates/parts/dlc-character-sheet-chips.html
+++ b/templates/parts/dlc-character-sheet-chips.html
@@ -45,3 +45,8 @@
     <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertTemporaryGreen" data-control="convertTemporaryGreen"> {{localize 'DLC.character.convertChip'}}</button>
   {{/if}}
 </div>
+
+<div class="chip-entry">
+  <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.drawOne"   data-control="drawOne">   {{localize 'DLC.character.drawOne'}}</button>
+  <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.drawThree" data-control="drawThree"> {{localize 'DLC.character.drawThree'}}</button>
+</div>

--- a/templates/parts/dlc-character-sheet-chips.html
+++ b/templates/parts/dlc-character-sheet-chips.html
@@ -1,16 +1,47 @@
 <h1>Tmp Header - Chips</h1>
 
-<form action="/">
-  <div class="chip-entry">
-    <div>White</div>
-    <div id="numWhiteChips">{{this.chips.white.value}}</div>
-    <div>Red</div>
-    <div id="numRedChips">{{this.chips.red.value}}</div>
-    <div>Blue</div>
-    <div id="numBlueChips">{{this.chips.blue.value}}</div>
-    <div>Green</div>
-    <div id="numGreenChips">{{this.chips.green.value}}</div>
-    <div>Ephemeral Green</div>
-    <div id="numEphGreenChips">{{this.chips.greenTemp.value}}</div>
-  </div>
-</form>
+<div class="chip-entry">
+  <div class="chip-label-character">White</div>
+  <div class="chip-quantity-character">{{this.chips.white}}</div>
+  {{#if chips.haswhite}}
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useWhite" data-control="useWhite">     {{localize 'DLC.character.useChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertWhite" data-control="convertWhite"> {{localize 'DLC.character.convertChip'}}</button>
+  {{/if}}
+</div>
+
+<div class="chip-entry">
+  <div class="chip-label-character">Red</div>
+  <div class="chip-quantity-character">{{this.chips.red}}</div>
+
+  {{#if chips.hasred}}
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useRed" data-control="useRed">     {{localize 'DLC.character.useChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertRed" data-control="convertRed"> {{localize 'DLC.character.convertChip'}}</button>
+  {{/if}}
+</div>
+
+<div class="chip-entry">
+  <div class="chip-label-character">Blue</div>
+  <div class="chip-quantity-character">{{this.chips.blue}}</div>
+
+  {{#if chips.hasblue}}
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useBlue" data-control="useBlue">     {{localize 'DLC.character.useChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertBlue" data-control="convertBlue"> {{localize 'DLC.character.convertChip'}}</button>
+  {{/if}}
+</div>
+<div class="chip-entry">
+  <div class="chip-label-character">Green</div>
+  <div class="chip-quantity-character">{{this.chips.green}}</div>
+  {{#if chips.hasgreen}}
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useGreen" data-control="useGreen">     {{localize 'DLC.character.useChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertGreen" data-control="convertGreen"> {{localize 'DLC.character.convertChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.consumeGreen" data-control="consumeGreen"> {{localize 'DLC.character.consumeChip'}}</button>
+  {{/if}}
+</div>
+<div class="chip-entry">
+  <div class="chip-label-character">Ephemeral Green</div>
+  <div class="chip-quantity-character">{{this.chips.temporaryGreen}}</div>
+  {{#if chips.hastemporaryGreen}}
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useTemporaryGreen" data-control="useTemporaryGreen">     {{localize 'DLC.character.useChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertTemporaryGreen" data-control="convertTemporaryGreen"> {{localize 'DLC.character.convertChip'}}</button>
+  {{/if}}
+</div>

--- a/templates/sidebar/chip-manager.html
+++ b/templates/sidebar/chip-manager.html
@@ -2,53 +2,67 @@
 
   <header class="chip-manager-header">
       <div class="flexrow">
-        <h3 class="chip-manager noborder">{{localize 'DLC.sidebar.ChipManager'}}</h3>
+        <h3 class="chip-manager noborder">{{localize 'DLC.sidebar.ChipPot'}}</h3>
       </div>
   </header>
 
-  <form>
-    <div class="chip-row">
-      <label class="chip-label" for="white">White</label>
-      <input class="chip-box" type="number" id="white" name="white" value="0" maxlength="2">
-    </div>
-    <div class="chip-row">
-      <label class="chip-label" for="red">Red</label>
-      <input class="chip-box" type="number" id="red" name="red" value="0" maxlength="2">
-    </div>
-    <div class="chip-row">
-      <label class="chip-label" for="blue">Blue</label>
-      <input class="chip-box" type="number" id="blue" name="blue" value="0" maxlength="2">
-    </div>
-    <div class="chip-row">
-      <label class="chip-label" for="green">Green</label>
-      <input class="chip-box" type="number" id="green" name="green" value="0" maxlength="2">
-    </div>
-    <div class="chip-row">
-      <label class="chip-label" for="tGreen">Temp Green</label>
-      <input class="chip-box" type="number" id="tGreen" name="tGreen" value="0" maxlength="2">
-    </div>
-    <ol id="chip-manager" class="directory-list">
-      {{#each posse as |actor id|}}
-        <div class="flexcol">
-          <li class="document chip-actor flexrow" data-actor-id="{{actor.id}}" data-index={{@index}}>
-            <img class="thumbnail" src="{{actor.img}}" data-src="{{actor.img}}" alt="{{actor.name}}"/>
-            <div class="token-name"><h4>{{actor.name}}</h4></div>
-            <input class="token-box" type="checkbox" name="{{actor.id}}" value="checked">
-          </li>
-        </div>
-      {{/each}}
-    </ol>
-    <input class="chip-allocate" type="submit" value="submit">
-  </form>
+  <div class="chip-row">
+    <label class="chip-label" for="white">White</label>
+    <span class="right">{{chips.white}}</span>
+  </div>
 
-  <nav id="chip-controls" class="flexrow" data-tooltip-direction="UP">
-    <a 
-    class="chip-control center" 
-    role="button"
-    data-control="allocateChips">
-      {{localize 'DLC.sidebar.AllocateChips'}}
-    </a>
-  </nav>
+  <div class="chip-row">
+    <label class="chip-label" for="red">Red</label>
+    <span class="right">{{chips.red}}</span>
+  </div>
 
+  <div class="chip-row">
+    <label class="chip-label" for="blue">Blue</label>
+    <span class="right">{{chips.blue}}</span>
+  </div>
+
+  <div class="chip-row">
+    <label class="chip-label" for="green">Green</label>
+    <span class="right">{{chips.green}}</span>
+  </div>
+
+  <div class="chip-manager-header flexrow">
+    <h3 class="chip-manager noborder">{{localize 'DLC.sidebar.MarshalsChips'}}</h3>
+  </div>
+
+  <div class="chip-row">
+    <label class="chip-label" for="white">White</label>
+    <span class="chip-quantity">{{chips.marshalWhite}}</span>
+
+    {{#if chips.hasWhite}}
+      <button class="chip-control chip-button-narrow right"  role="button" data-control="useMarshalWhite"> {{localize 'DLC.sidebar.UseMarshalWhite'}}</button>
+    {{/if}}
+  </div>
+
+  <div class="chip-row">
+    <label class="chip-label" for="red">Red</label>
+    <span class="chip-quantity">{{chips.marshalRed}}</span>
+
+    {{#if chips.hasRed}}
+      <button class="chip-control chip-button-narrow right"  role="button" data-control="useMarshalRed"> {{localize 'DLC.sidebar.UseMarshalRed'}} </button>
+    {{/if}}
+  </div>
+
+  <div class="chip-row">
+    <label class="chip-label" for="blue">Blue</label>
+    <span class="chip-quantity">{{chips.marshalBlue}}</span>
+
+    {{#if chips.hasBlue}}
+      <button class="chip-control chip-button-narrow right"  role="button" data-control="useMarshalBlue"> {{localize 'DLC.sidebar.UseMarshalBlue'}} </button>
+    {{/if}}
+  </div>
+
+  <div class="chip-manager-header flexrow">
+    <h3 class="chip-manager noborder"> &nbsp; </h3>
+  </div>
+
+  <button class="chip-control chip-button "  role="button" data-control="drawChip"> {{localize 'DLC.sidebar.DrawMarshalChip'}} </button>
+
+  <button class="chip-control chip-button "  role="button" data-control="chipAllocator"> {{localize 'DLC.sidebar.ChipAllocator'}} </button>
 
 </section>


### PR DESCRIPTION
Made the chip tab functional.

It shows the chip pot, and the marshal's chips.
It allows the marshal to use a chip and to draw a chip from the pot.

Additionally there is now a chip allocator app that allows the marshal to distribute chips.

Improved the assigning of chips to characters and added a report to chat.

Improved the chip tab on the character sheet. It now shows how many 
chips the character has, allows for random draw of one or three chips.
It allows for use (which does nothing other than report the "use" and
return the chip to the pot). Convert which reports and increases the 
character's bounty by the chip value. If a real green chip is present
it allows it to be destroyed.