### PR TITLE
Add chip draw to combat tracker

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -116,6 +116,10 @@
     },
 
     "settings": {
+      "chip-from-marshal-bJoker": {
+        "name": "Marshal black joker Chips",
+        "hint": "Does the marshal's black joker give them a chip?"
+      },
       "chips-blue": {
         "name": "Blue Chips",
         "hint": "How many blue chips exist in the pot."

--- a/lang/en.json
+++ b/lang/en.json
@@ -52,6 +52,7 @@
       "convertWhite": "Convert white chip to bounty",
       "useRed": "Use red chip",
       "convertRed": "Convert red chip to bounty",
+      "useRedReroll": "Use red chip for reroll",
       "useBlue": "Use blue chip",
       "convertBlue": "Convert blue chip to bounty",
       "useGreen": "Use green chip",
@@ -61,7 +62,8 @@
       "convertTemporaryGreen": "Convert temporary green chip to bounty",
       "consumeChip": "Consume",
       "convertChip": "Convert",
-      "useChip": "Use"
+      "useChip": "Use",
+      "useChipReroll": "Use for reroll"
     },
 
     "combat": {

--- a/module/helpers/chips.mjs
+++ b/module/helpers/chips.mjs
@@ -20,9 +20,7 @@ export class Chips {
   };
 
   static getColour(type) {
-    const key = Object.keys(Chips.type)[
-      Object.values(Chips.type).indexOf(type)
-    ];
+    const key = Object.keys(Chips.type).find(searchKey => Chips.type[searchKey] === type);
 
     return this.colour[key];
   }

--- a/module/helpers/chips.mjs
+++ b/module/helpers/chips.mjs
@@ -20,7 +20,11 @@ export class Chips {
   };
 
   static getColour(type) {
-    return this.colour(type);
+    const key = Object.keys(Chips.type)[
+      Object.values(Chips.type).indexOf(type)
+    ];
+
+    return this.colour[key];
   }
 
   // Choose a randomn chip from those available in the pot. The Marshall can't get green

--- a/module/init/settings.mjs
+++ b/module/init/settings.mjs
@@ -32,6 +32,15 @@ export function createGameSettings() {
     },
   });
 
+  game.settings.register('deadlands-classic', 'marshal-black-draw', {
+    name: 'DLC.settings.chip-from-marshal-bJoker.name',
+    hint: 'DLC.settings.chip-from-marshal-bJoker.hint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register('deadlands-classic', 'wildBlack', {
     name: 'DLC.settings.wild-black.name',
     hint: 'DLC.settings.wild-black.hint',

--- a/module/init/socket-functions.mjs
+++ b/module/init/socket-functions.mjs
@@ -17,6 +17,27 @@ function _chatMessage(
   ChatMessage.create(chatData);
 }
 
+/* Draws a random chip for the Marshall. Returns the value so that this can be
+   called from various places that need different reports to chat. */
+
+async function _drawChipMarshalBase() {
+  const chip = Chips.randomDraw(false);
+
+  const marshal = game.settings.get('deadlands-classic', 'marshal-chips');
+  const newMarshal = marshal.toObject();
+
+  if (chip === Chips.type.White) {
+    newMarshal.chips.white += 1;
+  } else if (chip === Chips.type.Red) {
+    newMarshal.chips.red += 1;
+  } else if (chip === Chips.type.Blue) {
+    newMarshal.chips.blue += 1;
+  }
+
+  await game.settings.set('deadlands-classic', 'marshal-chips', newMarshal);
+  return chip;
+}
+
 function socketLogCombatant(combatId, combatantId, index) {
   const combat = game.combats.get(combatId);
   const combatant = combat.combatants.get(combatantId);
@@ -133,20 +154,7 @@ async function socketDrawChipActor(actorId, num = 1, joker = false) {
 }
 
 async function socketDrawChipMarshal(joker = false) {
-  const chip = Chips.randomDraw(false);
-
-  const marshal = game.settings.get('deadlands-classic', 'marshal-chips');
-  const newMarshal = marshal.toObject();
-
-  if (chip === Chips.type.White) {
-    newMarshal.chips.white += 1;
-  } else if (chip === Chips.type.Red) {
-    newMarshal.chips.red += 1;
-  } else if (chip === Chips.type.Blue) {
-    newMarshal.chips.blue += 1;
-  }
-
-  await game.settings.set('deadlands-classic', 'marshal-chips', newMarshal);
+  const chip = await _drawChipMarshalBase();
 
   if (joker) {
     const colour = Chips.getColour(chip);
@@ -179,6 +187,27 @@ async function socketConsumeGreenChipActor(actorId) {
   _chatMessage(actor.name, actor.name, 'Consumed a Green chip');
 }
 
+async function socketRedRerollActor(actorId) {
+  const actor = game.actors.get(actorId);
+
+  if (actor.system.red < 1) {
+    _chatMessage(
+      actor.name,
+      actor.name,
+      'Attempted to reroll using a Red chip, but none was available!'
+    );
+    return;
+  }
+
+  actor.useChip(Chips.type.Red);
+  const chip = await _drawChipMarshalBase();
+
+  const colour = Chips.getColour(chip);
+  const message = `Marshal drew a ${colour} chip.`;
+
+  _chatMessage(ChatMessage.getSpeaker(), `Red chip reroll!`, message);
+}
+
 async function socketUseChipActor(actorId, chip) {
   const actor = game.actors.get(actorId);
   actor.useChip(chip);
@@ -201,5 +230,6 @@ export function registerSocketFunctions(socket) {
   socket.register('socketConsumeGreenChipActor', socketConsumeGreenChipActor);
   socket.register('socketDrawChipActor', socketDrawChipActor);
   socket.register('socketDrawChipMarshal', socketDrawChipMarshal);
+  socket.register('socketRedRerollActor', socketRedRerollActor);
   socket.register('socketUseChipActor', socketUseChipActor);
 }

--- a/module/init/socket-functions.mjs
+++ b/module/init/socket-functions.mjs
@@ -108,7 +108,7 @@ async function socketAddChipsActor(actorId, chips) {
   _chatMessage(ChatMessage.getSpeaker(), actor.name, message);
 }
 
-async function socketDrawChipActor(actorId, num = 1) {
+async function socketDrawChipActor(actorId, num = 1, joker = false) {
   const actor = game.actors.get(actorId);
 
   let chipobject = {
@@ -127,10 +127,12 @@ async function socketDrawChipActor(actorId, num = 1) {
   // Adding the randomly drawn chip.
   const message = await actor.addMultipleChips(chipobject);
 
-  _chatMessage(ChatMessage.getSpeaker(), actor.name, message);
+  const name = joker ? `Red joker — ${actor.name}` : actor.name;
+
+  _chatMessage(ChatMessage.getSpeaker(), name, message);
 }
 
-async function socketDrawChipMarshal() {
+async function socketDrawChipMarshal(joker = false) {
   const chip = Chips.randomDraw(false);
 
   const marshal = game.settings.get('deadlands-classic', 'marshal-chips');
@@ -145,6 +147,13 @@ async function socketDrawChipMarshal() {
   }
 
   await game.settings.set('deadlands-classic', 'marshal-chips', newMarshal);
+
+  if (joker) {
+    const colour = Chips.getColour(chip);
+    const message = `Drew a ${colour} chip.`;
+
+    _chatMessage(ChatMessage.getSpeaker(), 'Black Joker — Marshal', message);
+  }
 }
 
 async function socketConvertChipActor(actorId, chip) {

--- a/module/sheets/dlc-actor-sheet.mjs
+++ b/module/sheets/dlc-actor-sheet.mjs
@@ -146,6 +146,13 @@ export class DLCActorSheet extends ActorSheet {
         );
         break;
 
+      case 'useRedReroll':
+        await game['deadlands-classic'].socket.executeAsGM(
+          'socketRedRerollActor',
+          this.document.id
+        );
+        break;
+
       case 'useRed':
         await game['deadlands-classic'].socket.executeAsGM(
           'socketUseChipActor',

--- a/styles/dlc.css
+++ b/styles/dlc.css
@@ -158,6 +158,10 @@ li.combatant .roll:hover {
   flex: 0 0 calc(var(--sidebar-header-height) * 2px);
 }
 
+.chip-button-character {
+  width: 150px;
+  flex: 0 0 calc(var(--sidebar-header-height) * 2px);
+}
 .chip-button-narrow {
   width: 100px;
   flex: 0 0 calc(var(--sidebar-header-height) * 2px);

--- a/templates/parts/dlc-character-sheet-chips.html
+++ b/templates/parts/dlc-character-sheet-chips.html
@@ -1,4 +1,4 @@
-<h1>Tmp Header - Chips</h1>
+<h1>Chips</h1>
 
 <div class="chip-entry">
   <div class="chip-label-character">White</div>
@@ -16,6 +16,7 @@
   {{#if chips.hasred}}
     <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useRed" data-control="useRed">     {{localize 'DLC.character.useChip'}}</button>
     <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.convertRed" data-control="convertRed"> {{localize 'DLC.character.convertChip'}}</button>
+    <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.useRedReroll" data-control="useRedReroll"> {{localize 'DLC.character.useChipReroll'}}</button>
   {{/if}}
 </div>
 
@@ -46,7 +47,9 @@
   {{/if}}
 </div>
 
+<div class="chip-entry"><br></div>
+
 <div class="chip-entry">
-  <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.drawOne"   data-control="drawOne">   {{localize 'DLC.character.drawOne'}}</button>
-  <button class="chip-control chip-button-narrow-character" role="button" data-tooltip="DLC.character.drawThree" data-control="drawThree"> {{localize 'DLC.character.drawThree'}}</button>
+  <button class="chip-control chip-button-character" role="button" data-tooltip="DLC.character.drawOne"   data-control="drawOne">   {{localize 'DLC.character.drawOne'}}</button>
+  <button class="chip-control chip-button-character" role="button" data-tooltip="DLC.character.drawThree" data-control="drawThree"> {{localize 'DLC.character.drawThree'}}</button>
 </div>


### PR DESCRIPTION
Added a setting to determine whether the Marshal's deck generates a chip for the Marshal when a black joker is drawn (defaults to off).

Modified the Draw card socket functions (Posse and Marshal) to trigger a chip draw on a joker. The Marshall draw checks the setting.

Bugfix make Chips.getColour actually return a colour. Note this cannot distinguish between a green and temporary green, but is not used in a context where that matters.