### PR TITLE
Add secondary tabs and adding items to characters

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -72,13 +72,16 @@
       "improve": "Improve",
       "remove": "Remove",
 
-      "addConcentration": "Add",
-      "removeConcentration": "Remove",
-
       "decreaseAptitude": "Decrease the number of aptitude dice",
 
       "increaseAptitude": "Increase the number of aptitude dice",
       "increaseAptitudeCost": "Cost to increase the number of aptitude dice",
+
+      "addConcentration": "Add",
+      "removeConcentration": "Remove",
+
+      "editItem": "Edit item",
+      "removeItem": "Delete item",
 
       "decreaseTrait": "Decrease the number of trait dice",
       "decreaseTraitDieSize": "Decrease the size of the trait die",
@@ -129,8 +132,12 @@
           "label": "Item description"
         },
         "price": {
-          "tooltip": "The price of the Item (in cents)",
-          "label": "Weapon Price"
+          "tooltip": "The price of the Item",
+          "label": "Price (in cents)"
+        },
+        "quantity": {
+          "tooltip": "How many of this Item do we have",
+          "label": "Quantity"
         },
         "rangeIncrement": {
           "tooltip": "The range increment (multiple of 5 yards)",
@@ -268,15 +275,23 @@
       "chips": "Chips",
       "combat": "Combat",
       "edges": "Edges",
-      "gear": "Inventory",
+      "inventory": "Inventory",
       "main": "Main",
       "notes": "Notes",
       "spells": "Spells",
       "traits": "Traits",
 
+      "guns": "Guns",
+      "melee": "Melee weapons",
+      "otherRanged": "Other ranged weapons",
+      "misc": "Miscellaneous items",
+
       "create-aptitudes": "Initial aptitudes",
-      "create-edges": "Initial edges",
       "create-traits": "Initial traits",
+      "create-charMod": "Initial Character Modifications",
+      "create-hindrances": "Initial hindrances",
+      "create-edges": "Initial edges",
+      "create-spelllikes": "Initial spell likes",
 
       "modify-aptitudes": "Improve aptitudes",
       "modify-edges": "Improve edges",

--- a/module/data/misc-item-data.mjs
+++ b/module/data/misc-item-data.mjs
@@ -6,6 +6,7 @@ export class MiscItemDataModel extends foundry.abstract.TypeDataModel {
   static defineSchema() {
     return {
       ...dlcFields.itemCommonFields(),
+      ...dlcFields.integerNoMax('quantity', 1),
     };
   }
 }

--- a/module/deadlands-classic.mjs
+++ b/module/deadlands-classic.mjs
@@ -39,7 +39,7 @@ let socket;
 // Remove Comment and activate next line for Production
 // CONFIG.debug.hooks = false;
 // Temporary Setting for debugging
-CONFIG.debug.hooks = true;
+// CONFIG.debug.hooks = true;
 
 /**
  * Init hook.

--- a/module/documents/dlc-item.mjs
+++ b/module/documents/dlc-item.mjs
@@ -4,6 +4,7 @@ import { EditGunSheet } from '../sheets/item/edit-sheet-gun.mjs';
 import { EditMeleeSheet } from '../sheets/item/edit-sheet-melee.mjs';
 import { EditMiscItemSheet } from '../sheets/item/edit-sheet-misc-item.mjs';
 import { EditOtherRangedItemSheet } from '../sheets/item/edit-sheet-other-ranged-item.mjs';
+import { EditSheetOwnedItem } from '../sheets/item/edit-sheet-owned-item.mjs';
 
 export class DeadlandsItem extends Item {
   get isCharacterMod() {
@@ -46,6 +47,13 @@ export class DeadlandsItem extends Item {
     }
 
     return new EditMiscItemSheet({
+      document: this,
+      editable: true,
+    });
+  }
+
+  get ownedItemEditor() {
+    return new EditSheetOwnedItem({
       document: this,
       editable: true,
     });

--- a/module/sheets/actor-sheet-base.mjs
+++ b/module/sheets/actor-sheet-base.mjs
@@ -119,12 +119,15 @@ export class DLCActorSheetBase extends sheets.ActorSheetV2 {
     const { name, img } = this.actor;
     const owner = this.actor.isOwner;
 
+    const items = this._prepareItemsContext();
+
     context = foundry.utils.mergeObject(context, {
       actorId: this.actor.id,
       aptitudes,
       chips,
       cssClass: isEditable ? 'editable' : 'locked',
       isEditable,
+      ...items,
       img,
       name,
       owner,
@@ -141,4 +144,97 @@ export class DLCActorSheetBase extends sheets.ActorSheetV2 {
 
     return context;
   }
+
+  _prepareItemsContext() {
+    const edges = [];
+    const hindrances = [];
+    const spellLikes = [];
+    const guns = [];
+    const otherRangedItems = [];
+    const meleeItems = [];
+    const miscItems = [];
+
+    for (const i of this.document.items) {
+      if (i.system.price) {
+        i.system.displayprice = Math.floor(i.system.price / 100);
+      }
+
+      if (i.type === 'edge') {
+        edges.push(i);
+      } else if (i.type === 'hindrance') {
+        hindrances.push(i);
+      } else if (i.type === 'spellLike') {
+        spellLikes.push(i);
+      } else if (i.type === 'gun') {
+        guns.push(i);
+      } else if (i.type === 'otherRanged') {
+        otherRangedItems.push(i);
+      } else if (i.type === 'melee') {
+        meleeItems.push(i);
+      } else if (i.type === 'miscItem') {
+        miscItems.push(i);
+      }
+    }
+
+    edges.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    hindrances.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    spellLikes.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    guns.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    otherRangedItems.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    meleeItems.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    miscItems.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+
+    return {
+      edges,
+      hindrances,
+      spellLikes,
+      guns,
+      otherRangedItems,
+      meleeItems,
+      miscItems,
+    };
+  }
 }
+
+// Might add active effect and dropping folders of items later
+
+// /* -------------------------------------------- */
+
+// /**
+//  * Handle the dropping of ActiveEffect data onto an Actor Sheet
+//  * @param {DragEvent} event                  The concluding DragEvent which contains drop data
+//  * @param {object} data                      The data transfer extracted from the event
+//  * @returns {Promise<ActiveEffect|boolean>}  The created ActiveEffect object or false if it couldn't be created.
+//  * @protected
+//  */
+// async _onDropActiveEffect(event, data) {
+//   const effect = await ActiveEffect.implementation.fromDropData(data);
+//   if (!this.actor.isOwner || !effect) return false;
+//   if (effect.target === this.actor) return false;
+//   return ActiveEffect.create(effect.toObject(), { parent: this.actor });
+// }
+
+//   /* -------------------------------------------- */
+
+// /**
+//  * Handle dropping of a Folder on an Actor Sheet.
+//  * The core sheet currently supports dropping a Folder of Items to create all items as owned items.
+//  * @param {DragEvent} event     The concluding DragEvent which contains drop data
+//  * @param {object} data         The data transfer extracted from the event
+//  * @returns {Promise<Item[]>}
+//  * @protected
+//  */
+// async _onDropFolder(event, data) {
+//   if (!this.actor.isOwner) return [];
+//   const folder = await Folder.implementation.fromDropData(data);
+//   if (folder.type !== 'Item') return [];
+//   const droppedItemData = await Promise.all(
+//     folder.contents.map(async (item) => {
+//       if (!(document instanceof Item)) {
+//         item = await fromUuid(item.uuid);
+//       }
+//       return item.toObject();
+//     })
+//   );
+//   return this._onDropItemCreate(droppedItemData, event);
+// }

--- a/module/sheets/actor-sheet-modify.mjs
+++ b/module/sheets/actor-sheet-modify.mjs
@@ -59,11 +59,138 @@ export class ActorSheetModify extends api.HandlebarsApplicationMixin(
       template: 'systems/deadlands-classic/templates/char-modify/aptitudes.hbs',
       scrollable: [''],
     },
+    charMod: {
+      template: 'systems/deadlands-classic/templates/char-modify/charMod.hbs',
+      scrollable: [''],
+    },
     edges: {
       template: 'systems/deadlands-classic/templates/char-modify/edges.hbs',
       scrollable: [''],
     },
+    hindrances: {
+      template:
+        'systems/deadlands-classic/templates/char-modify/hindrances.hbs',
+      scrollable: [''],
+    },
+    spelllikes: {
+      template:
+        'systems/deadlands-classic/templates/char-modify/spelllikes.hbs',
+      scrollable: [''],
+    },
   };
+
+  /**
+   * Generates the data for the generic tab navigation template
+   * @returns {Record<string, Partial<ApplicationTab>>}
+   * @protected
+   */
+  _getTabs() {
+    // Default tab for first time it's rendered this session
+    if (!this.tabGroups.primary) this.tabGroups.primary = 'traits';
+
+    const activateaptitudes = this.tabGroups.primary === 'aptitudes';
+    const activatecharMod = this.tabGroups.primary === 'charMod';
+    const activatetraits = this.tabGroups.primary === 'traits';
+
+    const tabs = {
+      traits: {
+        cssClass: activatetraits ? 'active' : '',
+        group: 'primary',
+        id: 'traits',
+        label: 'DLC.tab.create-traits',
+      },
+      aptitudes: {
+        cssClass: activateaptitudes ? 'active' : '',
+        group: 'primary',
+        id: 'aptitudes',
+        label: 'DLC.tab.create-aptitudes',
+      },
+      charMod: {
+        cssClass: activatecharMod ? 'active' : '',
+        group: 'primary',
+        id: 'charMod',
+        label: 'DLC.tab.create-charMod',
+      },
+    };
+
+    return tabs;
+  }
+
+  /**
+   * Generates the data for the secondary tab navigation template
+   * @returns {Record<string, Partial<ApplicationTab>>}
+   * @protected
+   */
+  _getSecondaryTabs() {
+    // Default tab for first time it's rendered this session
+    if (!this.tabGroups.secondary) this.tabGroups.secondary = 'edges';
+
+    const activateedges =
+      this.tabGroups.primary === 'charMod' &&
+      this.tabGroups.secondary === 'edges';
+    const activatehindrances =
+      this.tabGroups.primary === 'charMod' &&
+      this.tabGroups.secondary === 'hindrances';
+    const activatespelllike =
+      this.tabGroups.primary === 'charMod' &&
+      this.tabGroups.secondary === 'spelllikes';
+
+    const secondaryTabs = {
+      edges: {
+        cssClass: activateedges ? 'active' : '',
+        group: 'secondary',
+        id: 'edges',
+        label: 'DLC.tab.create-edges',
+      },
+      hindrances: {
+        cssClass: activatehindrances === 'hindrances' ? 'active' : '',
+        group: 'secondary',
+        id: 'hindrances',
+        label: 'DLC.tab.create-hindrances',
+      },
+      spelllikes: {
+        cssClass: activatespelllike ? 'active' : '',
+        group: 'secondary',
+        id: 'spelllikes',
+        label: 'DLC.tab.create-spelllikes',
+      },
+    };
+
+    return secondaryTabs;
+  }
+
+  // prettier-ignore
+  changeTab(tab, group, { event, navElement, force = false, updatePosition = true } = {}) {
+    if (group === 'primary' && tab === 'charMod') {
+      const content = this.hasFrame
+        ? this.element.querySelector('.window-content')
+        : this.element;
+
+        for (const section of content.querySelectorAll(`.tab[data-group="secondary"]`)) {
+          section.classList.toggle('active', section.dataset.tab === this.tabGroups.secondary);
+        }
+    }
+
+    super.changeTab(tab, group, { event, navElement, force, updatePosition });
+  }
+
+  /** @override */
+  async _preparePartContext(partId, context) {
+    switch (partId) {
+      case 'aptitudes':
+      case 'traits':
+      case 'charMod':
+        context.tab = context.tabs[partId];
+        break;
+      case 'edges':
+      case 'hindrances':
+      case 'spelllikes':
+        context.tab = context.secondaryTabs[partId];
+        break;
+      default:
+    }
+    return context;
+  }
 
   /*--------------------------------------------------------------------------
   | If the aptitude has any concentrations, calculate how much (if anything)
@@ -282,75 +409,15 @@ export class ActorSheetModify extends api.HandlebarsApplicationMixin(
 
     context = foundry.utils.mergeObject(context, {
       tabs: this._getTabs(options.parts),
+      secondaryTabs: this._getSecondaryTabs(),
     });
 
     return context;
   }
 
-  /** @override */
-  async _preparePartContext(partId, context) {
-    switch (partId) {
-      case 'aptitudes':
-      case 'edges':
-      case 'traits':
-        context.tab = context.tabs[partId];
-        break;
-      default:
-    }
-    return context;
-  }
-
-  /**
-   * Generates the data for the generic tab navigation template
-   * @param {string[]} parts An array of named template parts to render
-   * @returns {Record<string, Partial<ApplicationTab>>}
-   * @protected
-   */
-  _getTabs(parts) {
-    // If you have sub-tabs this is necessary to change
-    const tabGroup = 'primary';
-
-    // Default tab for first time it's rendered this session
-    if (!this.tabGroups[tabGroup]) this.tabGroups[tabGroup] = 'traits';
-
-    return parts.reduce((tabs, partId) => {
-      const tab = {
-        cssClass: '',
-        group: tabGroup,
-        // Matches tab property to
-        id: '',
-        // FontAwesome Icon, if you so choose
-        icon: '',
-        // Run through localization
-        label: 'DLC.tab.',
-      };
-
-      switch (partId) {
-        case 'header':
-        case 'tabs':
-          return tabs;
-
-        case 'aptitudes':
-          tab.id = 'aptitudes';
-          tab.label += 'modify-aptitudes';
-          break;
-        case 'edges':
-          tab.id = 'edges';
-          tab.label += 'modify-edges';
-          break;
-        case 'traits':
-          tab.id = 'traits';
-          tab.label += 'modify-traits';
-          break;
-        default:
-      }
-
-      if (this.tabGroups[tabGroup] === tab.id) tab.cssClass = 'active';
-      // eslint-disable-next-line no-param-reassign
-      tabs[partId] = tab;
-      return tabs;
-    }, {});
-  }
+  /* ----------------------------------------------------------------------*/
+  /* Actions                                                               */
+  /* ----------------------------------------------------------------------*/
 
   static async _addConcentration(event, target) {
     event.preventDefault();

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-restricted-syntax */
 import { Chips } from '../helpers/chips.mjs';
@@ -12,6 +13,59 @@ const { api } = foundry.applications;
 export class DLCActorSheet extends api.HandlebarsApplicationMixin(
   DLCActorSheetBase
 ) {
+  constructor(options = {}) {
+    super(options);
+    this.#dragDrop = this.#createDragDropHandlers();
+  }
+
+  /* -------------------------------------------- */
+  /* Set up Drag and Drop                         */
+  /* -------------------------------------------- */
+
+  // The following pieces set up drag handling and are unlikely to
+  // need modification.
+
+  get dragDrop() {
+    return this.#dragDrop;
+  }
+
+  // This is marked as private because there's no real need
+  // for subclasses or external hooks to mess with it directly
+  #dragDrop;
+
+  /**
+   * Create drag-and-drop workflow handlers for this Application
+   * @returns {DragDrop[]}     An array of DragDrop handlers
+   * @private
+   */
+  #createDragDropHandlers() {
+    return this.options.dragDrop.map((d) => {
+      d.permissions = {
+        dragstart: this._canDragStart.bind(this),
+        drop: this._canDragDrop.bind(this),
+      };
+      d.callbacks = {
+        dragstart: this._onDragStart.bind(this),
+        dragover: this._onDragOver.bind(this),
+        drop: this._onDrop.bind(this),
+      };
+      return new DragDrop(d);
+    });
+  }
+
+  /**
+   * Actions performed after any render of the Application.
+   * Post-render steps are not awaited by the render process.
+   * @param {ApplicationRenderContext} context      Prepared context data
+   * @param {RenderOptions} options                 Provided render options
+   * @protected
+   */
+  _onRender(context, options) {
+    this.#dragDrop.forEach((d) => d.bind(this.element));
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   static DEFAULT_OPTIONS = {
     classes: ['dlc', 'sheet', 'actor'],
@@ -31,6 +85,8 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
       convertWhite: this._convertWhite,
       drawOne: this._drawOne,
       drawThree: this._drawThree,
+      editItem: this._editItem,
+      removeItem: this._removeItem,
       useBlue: this._useBlue,
       useGreen: this._useGreen,
       useRed: this._useRed,
@@ -39,6 +95,7 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
       useWhite: this._useWhite,
     },
     // Custom property that's merged into `this.options`
+    dragDrop: [{ dragSelector: '[data-drag]', dropSelector: null }],
     form: {
       submitOnChange: true,
     },
@@ -73,8 +130,24 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
       template: 'systems/deadlands-classic/templates/char-show/edges.hbs',
       scrollable: [''],
     },
-    gear: {
-      template: 'systems/deadlands-classic/templates/char-show/gear.hbs',
+    inventory: {
+      template: 'systems/deadlands-classic/templates/char-show/inventory.hbs',
+      scrollable: [''],
+    },
+    guns: {
+      template: 'systems/deadlands-classic/templates/char-show/guns.hbs',
+      scrollable: [''],
+    },
+    melee: {
+      template: 'systems/deadlands-classic/templates/char-show/melee.hbs',
+      scrollable: [''],
+    },
+    otherRanged: {
+      template: 'systems/deadlands-classic/templates/char-show/otherRanged.hbs',
+      scrollable: [''],
+    },
+    misc: {
+      template: 'systems/deadlands-classic/templates/char-show/misc.hbs',
       scrollable: [''],
     },
     spells: {
@@ -95,11 +168,105 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
     },
   };
 
+  /* Unfortunately need this. The standard changeTab wasn't handling a secondary 
+     set of tabs under the inventory primary tab. They were not getting the
+     active class removed from their classlist. This meant that once they have
+     been displayed, they never go away.
+     
+     When any primary tab is clicked, this operation sets the secondary tabs'
+     consfig appropraitely. It clears all active flags from the sub-tabs when
+     any primary tab other than the one containing the sub-tabs is selected.
+    
+     When the primary tab containing the secondary tabs (inventory) is selected,
+     this operation ensures that only the tab in this.tabGroups.secondary is
+     active.
+    
+     It then calls the super operation to do the actual change tab. Prettier
+     ignored because the lines aren't that long and it makes a right 
+     unreadable mess of them if you let it. */
+
+  // prettier-ignore
+  changeTab(tab, group, { event, navElement, force = false, updatePosition = true } = {}) {
+    if (group === 'primary' && tab === 'inventory') {
+      const content = this.hasFrame
+        ? this.element.querySelector('.window-content')
+        : this.element;
+
+        for (const section of content.querySelectorAll(`.tab[data-group="secondary"]`)) {
+          section.classList.toggle('active', section.dataset.tab === this.tabGroups.secondary);
+        }
+      }
+
+    super.changeTab(tab, group, { event, navElement, force, updatePosition });
+  }
+
+  // prettier-ignore
+  #fixSubTabs(tab, group) {
+    if (group === 'primary') {
+      const content = this.hasFrame
+        ? this.element.querySelector('.window-content')
+        : this.element;
+
+      if (tab === 'inventory') {
+        for (const section of content.querySelectorAll(`.tab[data-group="secondary"]`)) {
+          section.classList.toggle('active', section.dataset.tab === this.tabGroups.secondary);
+        }
+      } else {
+        for (const section of content.querySelectorAll(`.tab[data-group="secondary"]`)) {
+          section.classList.toggle('active', false);
+        }
+      }
+    }
+  }
+
   async _prepareContext(options) {
     let context = await super._prepareContext(options);
 
+    const intialiseSecondary = !this.tabGroups.secondary;
+
+    // Default tab for first time it's rendered this session
+    if (!this.tabGroups.primary) this.tabGroups.primary = 'aptitudes';
+    if (intialiseSecondary) this.tabGroups.secondary = 'guns';
+
+    const activateSecondary = this.tabGroups.primary === 'inventory';
+
+    const activateguns =
+      activateSecondary && this.tabGroups.secondary === 'guns';
+    const activatemelee =
+      activateSecondary && this.tabGroups.secondary === 'melee';
+    const activateranged =
+      activateSecondary && this.tabGroups.secondary === 'otherRanged';
+    const activatemisc =
+      activateSecondary && this.tabGroups.secondary === 'misc';
+
     context = foundry.utils.mergeObject(context, {
       tabs: this._getTabs(options.parts),
+      inventoryTabs: {
+        guns: {
+          cssClass: activateguns ? 'active' : '',
+          group: 'secondary',
+          id: 'guns',
+          label: 'DLC.tab.guns',
+        },
+        melee: {
+          cssClass: activatemelee ? 'active' : '',
+          group: 'secondary',
+          id: 'melee',
+          label: 'DLC.tab.melee',
+        },
+        otherRanged: {
+          cssClass: activateranged ? 'active' : '',
+          group: 'secondary',
+          id: 'otherRanged',
+          label: 'DLC.tab.otherRanged',
+        },
+        misc: {
+          cssClass: activatemisc ? 'active' : '',
+          group: 'secondary',
+          id: 'misc',
+          label: 'DLC.tab.misc',
+        },
+      },
     });
 
     return context;
@@ -108,12 +275,18 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
   /** @override */
   async _preparePartContext(partId, context) {
     switch (partId) {
+      case 'guns':
+      case 'melee':
+      case 'otherRanged':
+      case 'misc':
+        context.tab = context.inventoryTabs[partId];
+        break;
       case 'aptitudes':
       case 'biodata':
       case 'chips':
       case 'combat':
       case 'edges':
-      case 'gear':
+      case 'inventory':
       case 'spells':
       case 'traits':
         context.tab = context.tabs[partId];
@@ -162,77 +335,230 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
    * @protected
    */
   _getTabs(parts) {
-    // If you have sub-tabs this is necessary to change
-    const tabGroup = 'primary';
-
-    // Default tab for first time it's rendered this session
-    if (!this.tabGroups[tabGroup]) this.tabGroups[tabGroup] = 'aptitudes';
-
-    return parts.reduce((tabs, partId) => {
-      const tab = {
-        cssClass: '',
-        group: tabGroup,
-        // Matches tab property to
-        id: '',
-        // FontAwesome Icon, if you so choose
-        icon: '',
-        // Run through localization
-        label: 'DLC.tab.',
-      };
-
-      switch (partId) {
-        case 'header':
-        case 'tabs':
-          return tabs;
-        case 'aptitudes':
-          tab.id = 'aptitudes';
-          tab.label += 'aptitudes';
-          break;
-        case 'biodata':
-          tab.id = 'biodata';
-          tab.label += 'biodata';
-          break;
-        case 'chips':
-          tab.id = 'chips';
-          tab.label += 'chips';
-          break;
-        case 'combat':
-          tab.id = 'combat';
-          tab.label += 'combat';
-          break;
-        case 'edges':
-          tab.id = 'edges';
-          tab.label += 'edges';
-          break;
-        case 'gear':
-          tab.id = 'gear';
-          tab.label += 'gear';
-          break;
-        case 'spells':
-          tab.id = 'spells';
-          tab.label += 'spells';
-          break;
-        case 'traits':
-          tab.id = 'traits';
-          tab.label += 'traits';
-          break;
-        case 'biography':
-          tab.id = 'biography';
-          tab.label += 'biography';
-          break;
-        case 'notes':
-          tab.id = 'notes';
-          tab.label += 'notes';
-          break;
-        default:
-      }
-
-      if (this.tabGroups[tabGroup] === tab.id) tab.cssClass = 'active';
-      // eslint-disable-next-line no-param-reassign
-      tabs[partId] = tab;
-      return tabs;
-    }, {});
+    return {
+      aptitudes: {
+        cssClass: this.tabGroups.primary === 'aptitudes' ? 'active' : '',
+        group: 'primary',
+        id: 'aptitudes',
+        label: 'DLC.tab.aptitudes',
+      },
+      biodata: {
+        cssClass: this.tabGroups.primary === 'biodata' ? 'active' : '',
+        group: 'primary',
+        id: 'biodata',
+        label: 'DLC.tab.biodata',
+      },
+      chips: {
+        cssClass: this.tabGroups.primary === 'chips' ? 'active' : '',
+        group: 'primary',
+        id: 'chips',
+        label: 'DLC.tab.chips',
+      },
+      combat: {
+        cssClass: this.tabGroups.primary === 'combat' ? 'active' : '',
+        group: 'primary',
+        id: 'combat',
+        label: 'DLC.tab.combat',
+      },
+      edges: {
+        cssClass: this.tabGroups.primary === 'edges' ? 'active' : '',
+        group: 'primary',
+        id: 'edges',
+        label: 'DLC.tab.edges',
+      },
+      inventory: {
+        cssClass: this.tabGroups.primary === 'inventory' ? 'active' : '',
+        group: 'primary',
+        id: 'inventory',
+        label: 'DLC.tab.inventory',
+      },
+      spells: {
+        cssClass: this.tabGroups.primary === 'spells' ? 'active' : '',
+        group: 'primary',
+        id: 'spells',
+        label: 'DLC.tab.spells',
+      },
+      traits: {
+        cssClass: this.tabGroups.primary === 'traits' ? 'active' : '',
+        group: 'primary',
+        id: 'traits',
+        label: 'DLC.tab.traits',
+      },
+      biography: {
+        cssClass: this.tabGroups.primary === 'biography' ? 'active' : '',
+        group: 'primary',
+        id: 'biography',
+        label: 'DLC.tab.biography',
+      },
+      notes: {
+        cssClass: this.tabGroups.primary === 'notes' ? 'active' : '',
+        group: 'primary',
+        id: 'notes',
+        label: 'DLC.tab.notes',
+      },
+    };
   }
+
+  /* -------------------------------------------- */
+  /*  Drag and Drop                               */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _canDragStart(selector) {
+    return this.isEditable;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _canDragDrop(selector) {
+    return this.isEditable;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDragStart(event) {
+    const li = event.currentTarget;
+    if ('link' in event.target.dataset) return;
+
+    // Create drag data
+    let dragData;
+
+    // Owned Items
+    if (li.dataset.itemId) {
+      const item = this.actor.items.get(li.dataset.itemId);
+      dragData = item.toDragData();
+    }
+
+    // Active Effect
+    if (li.dataset.effectId) {
+      const effect = this.actor.effects.get(li.dataset.effectId);
+      dragData = effect.toDragData();
+    }
+
+    if (!dragData) return;
+
+    // Set data transfer
+    event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+  }
+
+  /**
+   * Callback actions which occur when a dragged element is over a drop target.
+   * @param {DragEvent} event       The originating DragEvent
+   * @protected
+   */
+  // eslint-disable-next-line class-methods-use-this
+  _onDragOver(event) {}
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDrop(event) {
+    const data = TextEditor.getDragEventData(event);
+    const { actor } = this;
+    const allowed = Hooks.call('dropActorSheetData', actor, this, data);
+    if (allowed === false) return false;
+
+    // Handle different data types
+    switch (data.type) {
+      case 'Item':
+        return this._onDropItem(event, data);
+      // case 'ActiveEffect':
+      //   return this._onDropActiveEffect(event, data);
+      // case 'Folder':
+      //   return this._onDropFolder(event, data);
+      default:
+        return false;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle dropping of an item reference or item data onto an Actor Sheet
+   * @param {DragEvent} event            The concluding DragEvent which contains drop data
+   * @param {object} data                The data transfer extracted from the event
+   * @returns {Promise<Item[]|boolean>}  The created or updated Item instances, or false if the drop was not permitted.
+   * @protected
+   */
+  async _onDropItem(event, data) {
+    if (!this.actor.isOwner) return false;
+    const item = await Item.implementation.fromDropData(data);
+
+    // Can't add or sort Character modifications with drag and drop on the actor.
+    if (item.isCharacterMod) return false;
+
+    const itemData = item.toObject();
+
+    // Handle item sorting within the same Actor
+    if (this.actor.uuid === item.parent?.uuid)
+      return this._onSortItem(event, itemData);
+
+    // Create the owned item
+    return this._onDropItemCreate(itemData, event);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle the final creation of dropped Item data on the Actor.
+   * This method is factored out to allow downstream classes the opportunity to override item creation behavior.
+   * @param {object[]|object} itemData      The item data requested for creation
+   * @param {DragEvent} event               The concluding DragEvent which provided the drop data
+   * @returns {Promise<Item[]>}
+   * @private
+   */
+  async _onDropItemCreate(itemData, event) {
+    const arrayofItems = itemData instanceof Array ? itemData : [itemData];
+    return this.actor.createEmbeddedDocuments('Item', arrayofItems);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle a drop event for an existing embedded Item to sort that Item relative to its siblings
+   * @param {Event} event
+   * @param {Object} itemData
+   * @private
+   */
+  _onSortItem(event, itemData) {
+    // Get the drag source and drop target
+    const { items } = this.actor;
+    const source = items.get(itemData._id);
+    const dropTarget = event.target.closest('[data-item-id]');
+    if (!dropTarget) return false;
+    const target = items.get(dropTarget.dataset.itemId);
+
+    // Don't sort on yourself
+    if (source.id === target.id) return false;
+
+    // Identify sibling items based on adjacent HTML elements
+    const siblings = [];
+    for (const el of dropTarget.parentElement.children) {
+      const siblingId = el.dataset.itemId;
+      if (siblingId && siblingId !== source.id)
+        siblings.push(items.get(el.dataset.itemId));
+    }
+
+    // Perform the sort
+    const sortUpdates = SortingHelpers.performIntegerSort(source, {
+      target,
+      siblings,
+    });
+    const updateData = sortUpdates.map((u) => {
+      const { update } = u;
+      update._id = u.target._id;
+      return update;
+    });
+
+    // Perform the update
+    return this.actor.updateEmbeddedDocuments('Item', updateData);
+  }
+
+  /* -------------------------------------------- */
+  /*  Sheet actions                               */
+  /* -------------------------------------------- */
 
   static async _useWhite(event, target) {
     event.preventDefault();
@@ -264,6 +590,21 @@ export class DLCActorSheet extends api.HandlebarsApplicationMixin(
       Chips.type.Red
     );
     this.render();
+  }
+
+  static async _editItem(event, target) {
+    event.preventDefault();
+    const element = event.target;
+    const { id } = element.dataset;
+    const item = this.document.items.get(id);
+    item.ownedItemEditor.render({ force: true });
+  }
+
+  static async _removeItem(event, target) {
+    event.preventDefault();
+    const element = event.target;
+    const { id } = element.dataset;
+    return this.actor.deleteEmbeddedDocuments('Item', [id]);
   }
 
   static async _useBlue(event, target) {

--- a/module/sheets/item/edit-sheet-owned-item.mjs
+++ b/module/sheets/item/edit-sheet-owned-item.mjs
@@ -1,0 +1,104 @@
+/* eslint-disable no-underscore-dangle */
+
+const { api, sheets } = foundry.applications;
+
+export class EditSheetOwnedItem extends api.HandlebarsApplicationMixin(
+  sheets.ItemSheetV2
+) {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ['dlc', 'sheet', 'item'],
+    position: {
+      width: 560,
+      height: 760,
+    },
+    window: {
+      resizable: true,
+    },
+    actions: {},
+    form: {
+      handler: this.#onSubmitMisc,
+      submitOnChange: true,
+    },
+  };
+
+  static PARTS = {
+    header: {
+      template: 'systems/deadlands-classic/templates/item/header.hbs',
+    },
+    body: {
+      template: 'systems/deadlands-classic/templates/item/owned-body.hbs',
+    },
+  };
+
+  isEditable(options = {}) {
+    return (options.editable ?? true) && super.isEditable;
+  }
+
+  async _prepareContext(options = {}) {
+    const editable = (options.editable ?? true) && this.isEditable(options);
+
+    return {
+      editable,
+
+      img: this.document.img,
+      limited: this.document.limited,
+      owner: this.document.isOwner,
+      system: this.document.system,
+      systemFields: this.document.system.schema.fields,
+
+      options: this.options,
+      title: this.title,
+    };
+  }
+
+  /** @override */
+  async _preparePartContext(partId, context) {
+    switch (partId) {
+      case 'header':
+        context.name = {
+          field: this.document.schema.getField('name'),
+          value: this.document.name,
+        };
+        break;
+      case 'body':
+        context.hasQuantity = this.document.type === 'miscItem';
+        context.quantity = context.hasQuantity
+          ? this.document.system.quantity
+          : 0;
+
+        context.data = {
+          price: {
+            tooltip: 'DLC.item.FIELDS.price.tooltip',
+          },
+          quantity: {
+            tooltip: 'DLC.item.FIELDS.quantity.tooltip',
+          },
+        };
+
+        context.notes = {
+          field: this.document.system.schema.getField('notes'),
+          enriched: await TextEditor.enrichHTML(this.item.system.notes, {
+            async: true,
+          }),
+          value: this.document.system.notes,
+        };
+        break;
+      default:
+    }
+    return context;
+  }
+
+  /**
+   * Process form submission for the sheet, removing overrides created by active effects
+   * @this {EditMiscSheet}               The handler is called with the application as its bound scope
+   * @param {SubmitEvent} event           The originating form submission event
+   * @param {HTMLFormElement} form        The form element that was submitted
+   * @param {FormDataExtended} formData   Processed data for the submitted form
+   * @returns {Promise<void>}
+   */
+  static async #onSubmitMisc(event, form, formData) {
+    const submitData = this._prepareSubmitData(event, form, formData);
+    await this.document.update(submitData);
+  }
+}

--- a/styles/dlc.css
+++ b/styles/dlc.css
@@ -696,3 +696,186 @@ li.combatant .roll:hover {
   height: var(--charsheet-item-height);
   width: 80px;
 }
+
+/* These control the gun sub-tab on the character inventory tab. */
+
+.inventory-gun-entry {
+  display: grid;
+  grid-template-columns: 180px 70px 70px 70px 70px 70px 50px 140px 100px;
+  grid-template-rows: 40px;
+  align-items: center;
+}
+
+.inventory-gun-name {
+  grid-column: 1;
+  font-weight: bold;
+  margin-left: 1em;
+}
+
+.inventory-gun-calibre {
+  grid-column: 2;
+  text-align: center;
+}
+
+.inventory-gun-damage {
+  grid-column: 3;
+  text-align: center;
+}
+
+.inventory-gun-rof {
+  grid-column: 4;
+  text-align: center;
+}
+
+.inventory-gun-shots {
+  grid-column: 5;
+  text-align: center;
+}
+
+.inventory-gun-range-increment {
+  grid-column: 6;
+  text-align: center;
+}
+
+.inventory-gun-price {
+  grid-column: 7;
+  text-align: right;
+}
+
+.inventory-gun-button1 {
+  grid-column: 8;
+  justify-self: center;
+  width: 100px;
+}
+
+.inventory-gun-button2 {
+  grid-column: 9;
+  justify-self: center;
+  width: 80px;
+}
+
+/* These control the melee sub-tab on the character inventory tab. */
+
+.inventory-melee-entry {
+  display: grid;
+  grid-template-columns: 180px 70px 70px 70px 70px 70px 50px 140px 100px;
+  grid-template-rows: 40px;
+  align-items: center;
+}
+
+.inventory-melee-name {
+  grid-column: 1;
+  font-weight: bold;
+  margin-left: 1em;
+}
+
+.inventory-melee-damage {
+  grid-column: 3;
+  text-align: center;
+}
+
+.inventory-melee-db {
+  grid-column: 4;
+  text-align: center;
+}
+
+.inventory-melee-price {
+  grid-column: 7;
+  text-align: right;
+}
+
+.inventory-melee-button1 {
+  grid-column: 8;
+  justify-self: center;
+  width: 100px;
+}
+
+.inventory-melee-button2 {
+  grid-column: 9;
+  justify-self: center;
+  width: 80px;
+}
+
+/* These control the other ranged sub-tab on the character inventory tab. */
+
+.inventory-other-ranged-entry {
+  display: grid;
+  grid-template-columns: 180px 70px 70px 70px 70px 70px 50px 140px 100px;
+  grid-template-rows: 40px;
+  align-items: center;
+}
+
+.inventory-other-ranged-name {
+  grid-column: 1;
+  font-weight: bold;
+  margin-left: 1em;
+}
+
+.inventory-other-ranged-ammo {
+  grid-column: 2;
+  text-align: center;
+}
+
+.inventory-other-ranged-damage {
+  grid-column: 3;
+  text-align: center;
+}
+
+.inventory-other-ranged-rof {
+  grid-column: 4;
+  text-align: center;
+}
+
+.inventory-other-ranged-range-increment {
+  grid-column: 6;
+  text-align: center;
+}
+
+.inventory-other-ranged-price {
+  grid-column: 7;
+  text-align: right;
+}
+
+.inventory-other-ranged-button1 {
+  grid-column: 8;
+  justify-self: center;
+  width: 100px;
+}
+
+.inventory-other-ranged-button2 {
+  grid-column: 9;
+  justify-self: center;
+  width: 80px;
+}
+
+/* These control the other ranged sub-tab on the character inventory tab. */
+
+.inventory-misc-entry {
+  display: grid;
+  grid-template-columns: 180px 70px 70px 70px 70px 70px 50px 140px 100px;
+  grid-template-rows: 40px;
+  align-items: center;
+}
+
+.inventory-misc-name {
+  grid-column: 1;
+  font-weight: bold;
+  margin-left: 1em;
+}
+
+.inventory-misc-price {
+  grid-column: 7;
+  text-align: right;
+}
+
+.inventory-misc-button1 {
+  grid-column: 8;
+  justify-self: center;
+  width: 100px;
+}
+
+.inventory-misc-button2 {
+  grid-column: 9;
+  justify-self: center;
+  width: 80px;
+}

--- a/templates/char-create/charMod.hbs
+++ b/templates/char-create/charMod.hbs
@@ -1,0 +1,15 @@
+{{! Inventory Tab }}
+<section
+  class='tab charMod {{tab.cssClass}}'
+  data-group='primary'
+  data-tab='charMod'
+>
+  <nav class="sheet-tabs tabs" aria-role="{{localize 'SHEETS.FormNavLabel'}}">
+      {{#each secondaryTabs as |tab|}}
+      <a class="{{tab.cssClass}}" data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+          <i class="{{tab.icon}}"></i>
+          <label>{{localize tab.label}}</label>
+      </a>
+      {{/each}}
+  </nav>
+</section>

--- a/templates/char-create/edges.hbs
+++ b/templates/char-create/edges.hbs
@@ -1,7 +1,7 @@
 {{! Edges Tab }}
 <section
   class='tab edges scrollable {{tab.cssClass}}'
-  data-group='primary'
+  data-group='secondary'
   data-tab='edges'>
-  <h1>Starting edges</h1>
+  Starting edges
 </section>

--- a/templates/char-create/hindrances.hbs
+++ b/templates/char-create/hindrances.hbs
@@ -1,0 +1,7 @@
+{{! Hindrances Tab }}
+<section
+  class='tab hindrances scrollable {{tab.cssClass}}'
+  data-group='secondary'
+  data-tab='hindrances'>
+  Starting hindrances
+</section>

--- a/templates/char-create/spelllikes.hbs
+++ b/templates/char-create/spelllikes.hbs
@@ -1,0 +1,7 @@
+{{! Spell Like Tab }}
+<section
+  class='tab spelllike scrollable {{tab.cssClass}}'
+  data-group='secondary'
+  data-tab='spelllikes'>
+  Starting Spell Like abilities
+</section>

--- a/templates/char-modify/charMod.hbs
+++ b/templates/char-modify/charMod.hbs
@@ -1,0 +1,15 @@
+{{! Inventory Tab }}
+<section
+  class='tab charMod {{tab.cssClass}}'
+  data-group='primary'
+  data-tab='charMod'
+>
+  <nav class="sheet-tabs tabs" aria-role="{{localize 'SHEETS.FormNavLabel'}}">
+      {{#each secondaryTabs as |tab|}}
+      <a class="{{tab.cssClass}}" data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+          <i class="{{tab.icon}}"></i>
+          <label>{{localize tab.label}}</label>
+      </a>
+      {{/each}}
+  </nav>
+</section>

--- a/templates/char-modify/edges.hbs
+++ b/templates/char-modify/edges.hbs
@@ -1,7 +1,7 @@
 {{! Edges Tab }}
 <section
   class='tab edges scrollable {{tab.cssClass}}'
-  data-group='primary'
+  data-group='secondary'
   data-tab='edges'>
-  <h1>Starting edges</h1>
+  Starting edges
 </section>

--- a/templates/char-modify/hindrances.hbs
+++ b/templates/char-modify/hindrances.hbs
@@ -1,0 +1,7 @@
+{{! Hindrances Tab }}
+<section
+  class='tab hindrances scrollable {{tab.cssClass}}'
+  data-group='secondary'
+  data-tab='hindrances'>
+  Starting hindrances
+</section>

--- a/templates/char-modify/spelllikes.hbs
+++ b/templates/char-modify/spelllikes.hbs
@@ -1,0 +1,7 @@
+{{! Spell Like Tab }}
+<section
+  class='tab spelllike scrollable {{tab.cssClass}}'
+  data-group='secondary'
+  data-tab='spelllikes'>
+  Starting Spell Like abilities
+</section>

--- a/templates/char-show/gear.hbs
+++ b/templates/char-show/gear.hbs
@@ -1,8 +1,0 @@
-{{! Gear Tab }}
-<section
-  class='tab gear {{tab.cssClass}}'
-  data-group='primary'
-  data-tab='gear'
->
-  <h1>Tmp Header - Inventory</h1>
-</section>

--- a/templates/char-show/guns.hbs
+++ b/templates/char-show/guns.hbs
@@ -1,0 +1,45 @@
+{{! Guns Tab }}
+<section class='tab guns {{tab.cssClass}}' data-group='secondary' data-tab='guns'>
+  {{! description notes }}
+  <div class="inventory-gun-entry">
+    <span class="inventory-gun-name"><strong>Name</strong></span>
+    <span class="inventory-gun-calibre"><strong>Calibre</strong></span>
+    <span class="inventory-gun-damage"><strong>Damage</strong></span>
+    <span class="inventory-gun-rof"><strong>Rof</strong></span>
+    <span class="inventory-gun-shots"><strong>Shots</strong></span>
+    <span class="inventory-gun-range-increment"><strong>Range Increment</strong></span>
+    <span class="inventory-gun-price"><strong>Price</strong></span>
+  </div>
+  <hr>
+
+  {{#each this.guns}}
+    <div class="inventory-gun-entry" data-tooltip="{{system.description}}">
+      <span class="inventory-gun-name">{{name}}</span>
+      <span class="inventory-gun-calibre">         {{system.calibre}}</span>
+      <span class="inventory-gun-damage">          {{system.damage}}</span>
+      <span class="inventory-gun-rof">             {{system.rof}}</span>
+      <span class="inventory-gun-shots">           {{system.shots}}</span>
+      <span class="inventory-gun-range-increment"> {{system.rangeIncrement}}</span>
+      <span class="inventory-gun-price">           {{system.displayprice}}</span>
+
+      <button 
+        class="inventory-gun-button1"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.removeItem"
+        data-action="removeItem">
+          {{localize 'DLC.character.removeItem'}}
+      </button>
+
+      <button 
+        class="inventory-gun-button2"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.editItem"
+        data-action="editItem">
+          {{localize 'DLC.character.editItem'}}
+      </button>
+
+    </div>
+  {{/each}}
+</section>

--- a/templates/char-show/inventory.hbs
+++ b/templates/char-show/inventory.hbs
@@ -1,0 +1,15 @@
+{{! Inventory Tab }}
+<section
+  class='tab inventory {{tab.cssClass}}'
+  data-group='primary'
+  data-tab='inventory'
+>
+  <nav class="sheet-tabs tabs" aria-role="{{localize 'SHEETS.FormNavLabel'}}">
+      {{#each inventoryTabs as |tab|}}
+      <a class="{{tab.cssClass}}" data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+          <i class="{{tab.icon}}"></i>
+          <label>{{localize tab.label}}</label>
+      </a>
+      {{/each}}
+  </nav>
+</section>

--- a/templates/char-show/melee.hbs
+++ b/templates/char-show/melee.hbs
@@ -1,0 +1,39 @@
+{{! Melee Tab }}
+<section class='tab melee {{tab.cssClass}}' data-group='secondary' data-tab='melee'>
+  {{! description notes }}
+  <div class="inventory-melee-entry">
+    <span class="inventory-melee-name"><strong>Name</strong></span>
+    <span class="inventory-melee-damage"><strong>Damage</strong></span>
+    <span class="inventory-melee-db"><strong>Damage bonus</strong></span>
+    <span class="inventory-melee-price"><strong>Price</strong></span>
+  </div>
+  <hr>
+
+  {{#each this.meleeItems}}
+    <div class="inventory-melee-entry" data-tooltip="{{system.description}}">
+      <span class="inventory-melee-name">            {{name}}</span>
+      <span class="inventory-melee-damage">          {{system.damage}}</span>
+      <span class="inventory-melee-db">              {{system.db}}</span>
+      <span class="inventory-melee-price">           {{system.displayprice}}</span>
+
+      <button 
+        class="inventory-melee-button1"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.removeItem"
+        data-action="removeItem">
+          {{localize 'DLC.character.removeItem'}}
+      </button>
+
+      <button 
+        class="inventory-melee-button2"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.editItem"
+        data-action="editItem">
+          {{localize 'DLC.character.editItem'}}
+      </button>
+
+    </div>
+  {{/each}}
+</section>

--- a/templates/char-show/misc.hbs
+++ b/templates/char-show/misc.hbs
@@ -1,0 +1,35 @@
+{{! Misc Tab }}
+<section class='tab misc {{tab.cssClass}}' data-group='secondary' data-tab='misc'>
+  {{! description notes }}
+  <div class="inventory-misc-entry">
+    <span class="inventory-misc-name"><strong>Name</strong></span>
+    <span class="inventory-misc-price"><strong>Price</strong></span>
+  </div>
+  <hr>
+
+  {{#each this.miscItems}}
+    <div class="inventory-misc-entry" data-tooltip="{{system.description}}">
+      <span class="inventory-misc-name">            {{name}}</span>
+      <span class="inventory-misc-price">           {{system.displayprice}}</span>
+
+      <button 
+        class="inventory-misc-button1"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.removeItem"
+        data-action="removeItem">
+          {{localize 'DLC.character.removeItem'}}
+      </button>
+
+      <button 
+        class="inventory-misc-button2"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.editItem"
+        data-action="editItem">
+          {{localize 'DLC.character.editItem'}}
+      </button>
+
+    </div>
+  {{/each}}
+</section>

--- a/templates/char-show/otherRanged.hbs
+++ b/templates/char-show/otherRanged.hbs
@@ -1,0 +1,43 @@
+{{! Other ranged Tab }}
+<section class='tab otherRanged {{tab.cssClass}}' data-group='secondary' data-tab='otherRanged'>
+  {{! description notes }}
+  <div class="inventory-other-ranged-entry">
+    <span class="inventory-other-ranged-name"><strong>Name</strong></span>
+    <span class="inventory-other-ranged-ammo"><strong>Ammunition</strong></span>
+    <span class="inventory-other-ranged-damage"><strong>Damage</strong></span>
+    <span class="inventory-other-ranged-rof"><strong>Rof</strong></span>
+    <span class="inventory-other-ranged-range-increment"><strong>Range Increment</strong></span>
+    <span class="inventory-other-ranged-price"><strong>Price</strong></span>
+  </div>
+  <hr>
+
+  {{#each this.otherRangedItems}}
+    <div class="inventory-other-ranged-entry" data-tooltip="{{system.description}}">
+      <span class="inventory-other-ranged-name">            {{name}}</span>
+      <span class="inventory-other-ranged-ammo">            {{system.ammo}}</span>
+      <span class="inventory-other-ranged-damage">          {{system.damage}}</span>
+      <span class="inventory-other-ranged-rof">             {{system.rof}}</span>
+      <span class="inventory-other-ranged-range-increment"> {{system.rangeIncrement}}</span>
+      <span class="inventory-other-ranged-price">           {{system.displayprice}}</span>
+
+      <button 
+        class="inventory-other-ranged-button1"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.removeItem"
+        data-action="removeItem">
+          {{localize 'DLC.character.removeItem'}}
+      </button>
+
+      <button 
+        class="inventory-other-ranged-button2"
+        type="button"
+        data-id="{{_id}}"
+        data-tooltip="DLC.character.editItem"
+        data-action="editItem">
+          {{localize 'DLC.character.editItem'}}
+      </button>
+
+    </div>
+  {{/each}}
+</section>

--- a/templates/item/owned-body.hbs
+++ b/templates/item/owned-body.hbs
@@ -1,0 +1,23 @@
+<div>
+  <div>
+    {{#if hasQuantity}}
+    {{formGroup systemFields.quantity value=system.quantity dataset=data.quantity}}
+    {{/if}}
+  </div>
+  <div>
+
+    {{#if editable}}
+      {{formGroup notes.field value=notes.value enriched=notes.enriched editable=editable height=200}}
+    {{else}}
+      <p>{{localize "DLC.item.FIELDS.notes.label"}}</p>
+      {{{notes.enriched}}}
+      <hr>
+    {{/if}}
+
+  </div>
+
+  <div>
+    {{formGroup systemFields.price value=system.price dataset=data.price}}
+  </div>
+
+</div>

--- a/templates/item/show-gun-sheet.html
+++ b/templates/item/show-gun-sheet.html
@@ -1,6 +1,0 @@
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img src="{{img}}" data-edit="img" title="{{name}}" height="64" width="64"/>
-    <h1>{{name}}</h1>
-  </header>
-</form>

--- a/templates/item/show-melee-sheet.html
+++ b/templates/item/show-melee-sheet.html
@@ -1,6 +1,0 @@
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img src="{{img}}" data-edit="img" title="{{name}}" height="64" width="64"/>
-    <h1>{{name}}</h1>
-  </header>
-</form>

--- a/templates/item/show-misc-item-sheet.html
+++ b/templates/item/show-misc-item-sheet.html
@@ -1,6 +1,0 @@
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img src="{{img}}" data-edit="img" title="{{name}}" height="64" width="64"/>
-    <h1>{{name}}</h1>
-  </header>
-</form>

--- a/templates/item/show-other-ranged-sheet.html
+++ b/templates/item/show-other-ranged-sheet.html
@@ -1,6 +1,0 @@
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img src="{{img}}" data-edit="img" title="{{name}}" height="64" width="64"/>
-    <h1>{{name}}</h1>
-  </header>
-</form>


### PR DESCRIPTION
Adding in logic to allow document sheets to have sub-tabs, i.e. a tabbed page that itself has tabs.

Added the ability to drag and drop items from the item browser to a character and have them added as embedded documents. This uses sub-tabs of the inventory tab to hold tabs for guns, melee weapons, other ranged weapons and miscellaneous items. There are also buttons to allow deleteion of the item and customisation of the item.

Note: A quantity field has been added to miscellaneous items, this will allow for things like arrows and bullets. We will want to track how many we have without cluttering the sheet with hunreds of individual bullets. Larger things like guns can have multiple of the same thing added, each of which can be given a specific name or a note.

Added tabs to the character create and character modify applications that are subtabs of a new character modification tab. There are tabs for edges, hindrances and spelllike abilities. No logic has yet been added for these.